### PR TITLE
Suppress an useless import avoid Java 6 build

### DIFF
--- a/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
@@ -24,7 +24,6 @@ import static org.libreplan.web.I18nHelper._;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.commons.logging.LogFactory;
 import org.libreplan.business.common.exceptions.InstanceNotFoundException;


### PR DESCRIPTION
java.util.Objects seems useless but cause compilation to fail with Java 6 (Objects has been added since Java 7). Alternative is to require Java 7 - that wouldn't be scandalous (and change doc accordingly)