### PR TITLE
Fix help generation

### DIFF
--- a/doc/tools/included.mk
+++ b/doc/tools/included.mk
@@ -8,7 +8,7 @@ utildir := SELF_DIR
 # Adrian Perez, 2009-05-15 11:20
 #
 
-RST_HTML_FLAGS = --link-stylesheet --stylesheet-path=html/lsr.css
+RST_HTML_FLAGS = --link-stylesheet --stylesheet=html/lsr.css
 RST_TEX_FLAGS  = --documentclass=igaliabk --font-encoding=OT1  --output-encoding=utf-8
 OUTPUT_BASE    = output
 

--- a/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
@@ -24,7 +24,6 @@ import static org.libreplan.web.I18nHelper._;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.commons.logging.LogFactory;
 import org.libreplan.business.common.exceptions.InstanceNotFoundException;

--- a/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/logs/IssueLogCRUDController.java
@@ -24,6 +24,7 @@ import static org.libreplan.web.I18nHelper._;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.logging.LogFactory;
 import org.libreplan.business.common.exceptions.InstanceNotFoundException;


### PR DESCRIPTION
The stylesheet-path option seems to be broken. Using stylesheet instead make the doc generation succeed : the help appears correctly again from the web application.