### PR TITLE
Add possibility to send data usage to LibrePlan server.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ ganttzk/target
 .project
 .settings/
 
-# ignore IDEA configuration files
+# ignore Intellij IDEA configuration files
 .idea
 *.iml
 

--- a/libreplan-business/src/main/java/org/libreplan/business/common/VersionInformation.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/common/VersionInformation.java
@@ -36,6 +36,7 @@ import org.apache.commons.logging.LogFactory;
  * published. It checks the last version against a URL.
  *
  * @author Susana Montes Pedreira <smontes@wirelessgalicia.com>
+ * @author Vova Perebykivskiy <vova@libreplan-enterprise.com>
  */
 public class VersionInformation {
 
@@ -118,14 +119,12 @@ public class VersionInformation {
     /**
      * Returns true if a new version of the project is published.
      *
-     * @param allowToGatherUsageStatsEnabled
+     * @param isCheckNewVersionEnabled
      *            If true LibrePlan developers will process the requests to check
      *            the new versions to generate usages statistics
      */
-    public static boolean isNewVersionAvailable(
-            boolean allowToGatherUsageStatsEnabled) {
-        return singleton
-                .checkIsNewVersionAvailable(allowToGatherUsageStatsEnabled);
+    public static boolean isNewVersionAvailable(boolean isCheckNewVersionEnabled) {
+        return singleton.checkIsNewVersionAvailable(isCheckNewVersionEnabled);
     }
 
     /**
@@ -133,13 +132,12 @@ public class VersionInformation {
      * Otherwise, during one day it returns the cached value. And it checks it
      * again after that time.
      */
-    private boolean checkIsNewVersionAvailable(
-            boolean allowToGatherUsageStatsEnabled) {
-        if (!newVersionCached) {
+    private boolean checkIsNewVersionAvailable(boolean isCheckNewVersionEnabled) {
+        if ( !newVersionCached ) {
             long oneDayLater = lastVersionCachedDate.getTime()
                     + DELAY_TO_CHECK_URL;
-            if (oneDayLater < new Date().getTime()) {
-                loadNewVersionFromURL(allowToGatherUsageStatsEnabled);
+            if ( oneDayLater < new Date().getTime() ) {
+                loadNewVersionFromURL(isCheckNewVersionEnabled);
             }
         }
         return newVersionCached;

--- a/libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java
@@ -37,6 +37,7 @@ import org.libreplan.business.costcategories.entities.TypeOfWorkHours;
  * @author Cristina Alvarino Perez <cristina.alvarino@comtecsf.es>
  * @author Ignacio Diaz Teijido <ignacio.diaz@comtecsf.es>
  * @author Susana Montes Pedreira <smontes@wirelessgalicia.com>
+ * @author Vova Perebykivskiy <vova@libreplan-enterprise.com>
  */
 public class Configuration extends BaseEntity {
 
@@ -100,7 +101,7 @@ public class Configuration extends BaseEntity {
 
     private Boolean checkNewVersionEnabled = true;
 
-    private Boolean allowToGatherUsageStatsEnabled = false;
+    private Boolean allowToGatherUsageStatsEnabled = true;
 
     private Boolean generateCodeForExpenseSheets = true;
 

--- a/libreplan-business/src/main/java/org/libreplan/business/users/daos/UserDAO.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/users/daos/UserDAO.java
@@ -182,6 +182,7 @@ public class UserDAO extends GenericDAOHibernate<User, Long>
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Number getRowCount() {
         return (Number) getSession().createCriteria(User.class).setProjection(Projections.rowCount()).uniqueResult();
     }

--- a/libreplan-business/src/main/resources/libreplan.properties
+++ b/libreplan-business/src/main/resources/libreplan.properties
@@ -1,0 +1,1 @@
+statsPage http://stats.libreplan-enterprise.com/

--- a/libreplan-webapp/src/main/java/org/libreplan/web/common/GatheredUsageStats.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/common/GatheredUsageStats.java
@@ -1,0 +1,185 @@
+package org.libreplan.web.common;
+
+import org.libreplan.business.common.VersionInformation;
+import org.libreplan.business.users.daos.IUserDAO;
+import org.libreplan.web.orders.IOrderModel;
+import org.springframework.security.context.SecurityContextHolder;
+import org.springframework.security.ui.WebAuthenticationDetails;
+import org.zkoss.json.JSONObject;
+import org.zkoss.zk.ui.Execution;
+import org.zkoss.zk.ui.Executions;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+
+/**
+ * Class represents all data that will be sent to server.
+ *
+ * If you want to use it, just create a new object and set 2 private variables.
+ * All needed data will be already in object.
+ *
+ * Created by
+ * @author Vova Perebykivskiy <vova@libreplan-enterprise.com>
+ * on 02/08/2016.
+ */
+
+public class GatheredUsageStats {
+
+    private IUserDAO userDAO;
+
+    private IOrderModel orderModel;
+
+
+    // Version of this statistics implementation
+    private int jsonObjectVersion = 1;
+
+    // Unique system identifier (MD5 - ip + hostname)
+    private String id;
+
+    // Version of LibrePlan
+    private String version = VersionInformation.getVersion();
+
+    // Number of users in application
+    private Number users;
+
+    // Number of projects in application
+    private int projects;
+
+    private Number getUserRows(){
+        return userDAO.getRowCount();
+    }
+
+    private String generateID(){
+        // Make hash of ip + hostname
+        WebAuthenticationDetails details = (WebAuthenticationDetails) SecurityContextHolder.getContext()
+                .getAuthentication().getDetails();
+        String ip = details.getRemoteAddress();
+
+        Execution execution = Executions.getCurrent();
+        String hostname = execution.getServerName();
+
+        String message = ip + hostname;
+        byte[] encoded = null;
+        StringBuffer sb = null;
+
+        try {
+            byte[] bytesOfMessage = message.getBytes("UTF-8");
+            MessageDigest md5 = MessageDigest.getInstance("MD5");
+            encoded = md5.digest(bytesOfMessage);
+
+            // Convert bytes to hex format
+            sb = new StringBuffer();
+            for (int i = 0; i < encoded.length; i++) sb.append(Integer.toString((encoded[i] & 0xff) + 0x100, 16)
+                    .substring(1));
+
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return sb.toString();
+    }
+
+    // It needed because i do not need to call default constructor on Autowiring
+    private void myConstructor(){
+        setId(generateID());
+        setUsers(getUserRows());
+        setProjects(orderModel.getOrders().size());
+    }
+
+    public void sendGatheredUsageStatsToServer(){
+        JSONObject json = new JSONObject();
+
+        json.put("json-version", jsonObjectVersion);
+        json.put("id", id);
+        json.put("version", version);
+        json.put("users", users);
+        json.put("projects", projects);
+
+        HttpURLConnection connection = null;
+
+        Properties properties = new Properties();
+        InputStream inputStream = null;
+
+        try {
+            String filename = "libreplan.properties";
+            inputStream = GatheredUsageStats.class.getClassLoader().getResourceAsStream(filename);
+            properties.load(inputStream);
+
+            URL url = new URL(properties.getProperty("statsPage"));
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/x-www-urlencoded");
+            connection.setRequestProperty("Content-Language", "en-GB");
+            connection.setRequestProperty("Content-Length", Integer.toString(json.toJSONString().getBytes().length));
+            connection.setUseCaches(false);
+            connection.setDoInput(true);
+            connection.setDoOutput(true);
+            // If the connection lasts > 2 sec throw Exception
+            connection.setConnectTimeout(2000);
+
+            // Send request
+            DataOutputStream dataOutputStream = new DataOutputStream(connection.getOutputStream());
+            dataOutputStream.writeBytes(json.toJSONString());
+            dataOutputStream.flush();
+            dataOutputStream.close();
+
+            // No needed code, but it is not working without id
+            connection.getInputStream();
+
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        finally {
+            if ( connection != null ) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    public void setupNotAutowiredClasses(IUserDAO userDAO, IOrderModel orderModel){
+        this.userDAO = userDAO;
+        this.orderModel = orderModel;
+        myConstructor();
+    }
+
+    public int getJsonObjectVersion() {
+        return jsonObjectVersion;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public Number getUsers() {
+        return users;
+    }
+    public void setUsers(Number users) {
+        this.users = users;
+    }
+
+    public int getProjects() {
+        return projects;
+    }
+    public void setProjects(int projects) {
+        this.projects = projects;
+    }
+}

--- a/libreplan-webapp/src/main/java/org/libreplan/web/common/TemplateController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/common/TemplateController.java
@@ -72,7 +72,7 @@ public class TemplateController extends GenericForwardComposer {
         if (templateModel.isScenariosVisible()) {
             window = (Window) comp.getFellow("changeScenarioWindow");
             windowMessages = new MessagesForUser(window
-                .getFellow("messagesContainer"));
+                    .getFellow("messagesContainer"));
         }
     }
 
@@ -219,12 +219,11 @@ public class TemplateController extends GenericForwardComposer {
     }
 
     public boolean isNewVersionAvailable() {
-        if (!templateModel.isCheckNewVersionEnabled()) {
+        if ( !templateModel.isCheckNewVersionEnabled() ) {
             return false;
         }
 
-        return VersionInformation.isNewVersionAvailable(templateModel
-                .isAllowToGatherUsageStatsEnabled());
+        return VersionInformation.isNewVersionAvailable(templateModel.isCheckNewVersionEnabled());
     }
 
     public String getUsername() {


### PR DESCRIPTION
Send anonymous usage data to LibrePlan server in JSON array.
Currently gathered usage data looks like: 
**JSON version**
**ID** (MD5 hash of IP address and hostname)
**LibrePlan version**
Number of **users** in application
Number of **projects** in application

Page where data will be sent may be changed in libreplan.properties file.
Also some minor remarks.