### PR TITLE
Bugfix: Replaced deprecated .class.name call.

### DIFF
--- a/libreplan-webapp/src/main/webapp/common/layout/login.zul
+++ b/libreplan-webapp/src/main/webapp/common/layout/login.zul
@@ -132,13 +132,13 @@
 
                 <n:td width="450" height="165" valign="top">
 
-                    <html if="${loginError == 'true' and SPRING_SECURITY_LAST_EXCEPTION.class.name == 'org.springframework.security.authentication.DisabledException'}">
+                    <html if="${loginError == 'true' and SPRING_SECURITY_LAST_EXCEPTION['class'].name == 'org.springframework.security.authentication.DisabledException'}">
                         <![CDATA[
                             <div class="login_ERROR">${i18n:_('User disabled')}</div>
                         ]]>
                     </html>
 
-                    <html if="${loginError == 'true' and SPRING_SECURITY_LAST_EXCEPTION.class.name == 'org.springframework.security.authentication.BadCredentialsException'}">
+                    <html if="${loginError == 'true' and SPRING_SECURITY_LAST_EXCEPTION['class'].name == 'org.springframework.security.authentication.BadCredentialsException'}">
                         <![CDATA[
                             <div class="login_ERROR">${i18n:_('Incorrect authentication')}</div>
                         ]]>


### PR DESCRIPTION
The call to foo.class.name in JSP is deprecated and crashes in modern servers with the error message 

> The identifier [class] is not a valid Java identifier as required by section 1.19 of the EL specification (Identifier ::= Java language identifier). This check can be disabled by setting the system property org.zkoss.zel.impl.parser.SKIP_IDENTIFIER_CHECK to true.

A proper replacement is foo['class'].name

See also https://www.logicbig.com/how-to/jsp/jsp-not-valid-java-identifier-exception.html