### PR TITLE
Small change in documentation

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -56,7 +56,7 @@ Debian/Ubuntu
 
 * Connect to database::
 
-    # su postgres -c psql
+    # sudo -u postgres psql
 
 * Use SQL sentences::
 


### PR DESCRIPTION
On Debian/Ubuntu, use 'sudo -u postgres ' instead of 'su postgres -c' to connect to postgresql