### PR TITLE
Bugfix: #1922 Unintended horizontal shift between Gantt and Resource view

### DIFF
--- a/ganttzk/src/main/java/org/zkoss/ganttz/Planner.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/Planner.java
@@ -620,7 +620,12 @@ public class Planner extends HtmlMacroComponent  {
 
         westContainer.addEventListener(
                 Events.ON_SIZE,
-                event -> Clients.evalJavaScript("ganttz.TaskList.getInstance().legendResize();"));
+                event -> Clients.evalJavaScript("ganttz.TaskList.getInstance().legendResize();")
+        );
+
+        // Force layout resize after composition. Otherwise the legend will be
+        // too small and the chart will be out of sync to the Gantt diagram.
+        Clients.evalJavaScript("ganttz.TaskList.getInstance().legendResize();");
 
     }
 

--- a/ganttzk/src/main/resources/web/js/ganttz/TaskList.js
+++ b/ganttzk/src/main/resources/web/js/ganttz/TaskList.js
@@ -29,8 +29,12 @@ ganttz.TaskList = zk.$extends(
         },
 
         legendResize : function() {
+            console.log("LegendResize");
+            // Calculate width dependant to the preceeding elements. Otherwise
+            // the elements will be horizontally shifted.
             var taskdetailsContainer = jq('.taskdetailsContainer')[0];
-            jq('.legend-container').width(taskdetailsContainer.clientWidth - 75);
+            var tabControl = jq('.legend-container').closest('.z-tabbox').find('.charts-tabbox');
+            jq('.legend-container').width(taskdetailsContainer.clientWidth - tabControl.width()); // 75px is the width of the tabs on the left
         },
 
         refreshTooltips : function() {


### PR DESCRIPTION
Fixed issue by calculating required width in JavaScript on demand.