### PR TITLE
Make build work in Ubuntu 20.04 with openjdk-8-jdk without working tests (yet)

### DIFF
--- a/libreplan-business/pom.xml
+++ b/libreplan-business/pom.xml
@@ -43,6 +43,13 @@
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
+		</dependency>
+
+        <!-- Annotation-api added to support jdk8 -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
         </dependency>
 
         <!-- Usertype.Core -->

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,13 @@
                 <groupId>javax.el</groupId>
                 <artifactId>javax.el-api</artifactId>
                 <version>3.0.0</version>
+			</dependency>
+
+			<!-- Annotation-api added to support jdk8 -->
+			<dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
             </dependency>
 
             <!-- Usertype.Core ( Significant for Hibernate ) -->


### PR DESCRIPTION
Make build work in Ubuntu 20.04 with openjdk-8-jdk without working tests (yet)