### PR TITLE
Updated PostgreSQL JDBC Driver to 42.2.25.jre7 for SCRAM authentication.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <!-- JDBC driver properties -->
                 <jdbcDriver.groupId>org.postgresql</jdbcDriver.groupId>
                 <jdbcDriver.artifactId>postgresql</jdbcDriver.artifactId>
-                <jdbcDriver.version>42.2.4.jre7</jdbcDriver.version>
+                <jdbcDriver.version>42.2.25.jre7</jdbcDriver.version>
                 <jdbcDriver.className>org.postgresql.Driver</jdbcDriver.className>
                 <!-- Data source properties -->
                 <dataSource.url>jdbc:postgresql://localhost/libreplan${libreplan.mode}</dataSource.url>


### PR DESCRIPTION
Ubunutu 22.04's postgresql version is 14 and uses SCRAM per default:
https://www.percona.com/blog/postgresql-14-and-recent-scram-authentication-changes-should-i-migrate-to-scram/