### PR TITLE
Upgrading jackson rest api lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,12 +632,12 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>2.7.4</version>
+                <version>2.17.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
-                <version>2.7.4</version>
+                <version>2.17.2</version>
             </dependency>
 
             <!-- ZK Timeplot -->


### PR DESCRIPTION
Upgrading jackson rest api lib.
Version bump from 1.7.4 to 1.17.2.
Tested rest services and they still work.