### PR TITLE
Add Ukrainian (uk) translation for LibrePlan UI

### DIFF
--- a/ganttzk/src/main/resources/i18n/uk.po
+++ b/ganttzk/src/main/resources/i18n/uk.po
@@ -1,0 +1,267 @@
+# Ukrainian translation for LibrePlan (ganttzk).
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+#
+# Translators:
+msgid ""
+msgstr ""
+"Project-Id-Version: LibrePlan\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-11-27 20:07+0100\n"
+"PO-Revision-Date: 2026-04-23 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: Ukrainian\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: uk\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
+"%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul:29
+msgid "Start"
+msgstr "Початок"
+
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:271
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:278
+msgid "The date you entered is invalid"
+msgstr "Введена дата недійсна"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:159
+msgid "showing resources"
+msgstr "показ ресурсів"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:102
+msgid "Show/Hide money cost bar"
+msgstr "Показати/Приховати панель грошових витрат"
+
+#: org/zkoss/ganttz/data/resourceload/TimeLineRole.java:59
+msgid "Task"
+msgstr "Завдання"
+
+#: org/zkoss/ganttz/timetracker/zoom/ZoomLevel.java:58
+msgid "Month"
+msgstr "Місяць"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:475
+msgid "Show all elements"
+msgstr "Показати всі елементи"
+
+#: org/zkoss/ganttz/timetracker/TimeTracker.java:229
+msgid "changing zoom"
+msgstr "зміна масштабу"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:96
+msgid "Show/Hide reported hours"
+msgstr "Показати/Приховати зареєстровані години"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:49
+msgid "Print"
+msgstr "Друк"
+
+#: org/zkoss/ganttz/timetracker/zoom/ZoomLevel.java:34
+msgid "Year"
+msgstr "Рік"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:71
+msgid "Show/Hide resources"
+msgstr "Показати/Приховати ресурси"
+
+#: org/zkoss/ganttz/Planner.java:326
+msgid "increasing zoom"
+msgstr "збільшення масштабу"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul:30
+msgid "End"
+msgstr "Кінець"
+
+#: org/zkoss/ganttz/DependencyList.java:236
+msgid "Set End-End"
+msgstr "Встановити Кінець-Кінець"
+
+#: org/zkoss/ganttz/Planner.java:464
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:398
+msgid "Graphics are disabled"
+msgstr "Графіку вимкнено"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul:28
+#: ganttzk/src/main/resources/web/ganttz/zul/resourcesLoadLayout.zul:77
+msgid "Name"
+msgstr "Назва"
+
+#: org/zkoss/ganttz/timetracker/zoom/ZoomLevel.java:46
+msgid "Quarter"
+msgstr "Квартал"
+
+#: org/zkoss/ganttz/DependencyList.java:213
+#: org/zkoss/ganttz/DependencyList.java:228
+msgid "Erase"
+msgstr "Видалити"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:474
+msgid "All"
+msgstr "Всі"
+
+#: org/zkoss/ganttz/Planner.java:344
+msgid "decreasing zoom"
+msgstr "зменшення масштабу"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:88
+msgid "Show/Hide progress"
+msgstr "Показати/Приховати прогрес"
+
+#: org/zkoss/ganttz/timetracker/zoom/ZoomLevel.java:70
+msgid "Week"
+msgstr "Тиждень"
+
+#: org/zkoss/ganttz/resourceload/ResourceLoadLeftPane.java:170
+msgid "See scheduling"
+msgstr "Переглянути планування"
+
+#: org/zkoss/ganttz/DependencyList.java:232
+msgid "Set End-Start"
+msgstr "Встановити Кінець-Початок"
+
+#: org/zkoss/ganttz/DependencyList.java:234
+msgid "Set Start-Start"
+msgstr "Встановити Початок-Початок"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:88
+msgid "Generic allocation criteria"
+msgstr "Критерії загального розподілу"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:67
+msgid "Show/Hide labels"
+msgstr "Показати/Приховати мітки"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:81
+msgid "Flatten/Unflatten tree"
+msgstr "Згорнути/Розгорнути дерево"
+
+#: org/zkoss/ganttz/DependencyList.java:66
+msgid "The specified dependency is not allowed"
+msgstr "Вказана залежність не дозволена"
+
+#: org/zkoss/ganttz/data/resourceload/TimeLineRole.java:57
+msgid "Worker"
+msgstr "Працівник"
+
+#: org/zkoss/ganttz/Planner.java:712
+msgid "Show money cost bar"
+msgstr "Показати панель грошових витрат"
+
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:273
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:280
+msgid "and no later than"
+msgstr "і не пізніше ніж"
+
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:272
+#: org/zkoss/ganttz/LeftTasksTreeRow.java:279
+msgid "Please enter date not before"
+msgstr "Будь ласка, введіть дату не раніше"
+
+#: org/zkoss/ganttz/Planner.java:643
+msgid "Show critical path"
+msgstr "Показати критичний шлях"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/resourcesLoadLayout.zul:50
+msgid "Page"
+msgstr "Сторінка"
+
+#: org/zkoss/ganttz/TaskList.java:298
+msgid "Add Dependency"
+msgstr "Додати залежність"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/resourcesLoadLayout.zul:38
+msgid "Zoom"
+msgstr "Масштаб"
+
+#: org/zkoss/ganttz/Planner.java:679
+msgid "Hide progress"
+msgstr "Приховати прогрес"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:510
+msgid "filtering by name"
+msgstr "фільтрування за назвою"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:76
+msgid "Expand/Collapse all"
+msgstr "Розгорнути/Згорнути все"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/leftTasksTree.zul:31
+msgid "T / M"
+msgstr "З / В"
+
+#: org/zkoss/ganttz/Planner.java:693
+msgid "Show reported hours"
+msgstr "Показати зареєстровані години"
+
+#: org/zkoss/ganttz/Planner.java:717
+msgid "Hide money cost bar"
+msgstr "Приховати панель грошових витрат"
+
+#: org/zkoss/ganttz/Planner.java:648
+msgid "Hide critical path"
+msgstr "Приховати критичний шлях"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:63
+msgid "Show/Hide critical path"
+msgstr "Показати/Приховати критичний шлях"
+
+#: org/zkoss/ganttz/Planner.java:670
+msgid "Show progress"
+msgstr "Показати прогрес"
+
+#: org/zkoss/ganttz/data/resourceload/TimeLineRole.java:56
+msgid "None"
+msgstr "Немає"
+
+#: org/zkoss/ganttz/data/resourceload/TimeLineRole.java:58
+msgid "Project"
+msgstr "Проєкт"
+
+#: org/zkoss/ganttz/timetracker/zoom/ZoomLevel.java:82
+msgid "Day"
+msgstr "День"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:162
+msgid "showing criteria"
+msgstr "показ критеріїв"
+
+#: org/zkoss/ganttz/resourceload/ResourcesLoadPanel.java:86
+msgid "Resources"
+msgstr "Ресурси"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:138
+#: ganttzk/src/main/resources/web/ganttz/zul/resourcesLoadLayout.zul:103
+msgid "Graphics"
+msgstr "Графіка"
+
+#: org/zkoss/ganttz/resourceload/ResourceLoadComponent.java:147
+msgid "See resource allocation"
+msgstr "Переглянути розподіл ресурсів"
+
+#: org/zkoss/ganttz/resourceload/ResourceLoadComponent.java:184
+msgid "Load: {0}%"
+msgstr "Завантаження: {0}%"
+
+#: org/zkoss/ganttz/resourceload/ResourceLoadComponent.java:192
+msgid "available effort: {0}, assigned effort: {1}"
+msgstr "доступне зусилля: {0}, призначене зусилля: {1}"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/resourcesLoadLayout.zul:56
+msgid "Group by"
+msgstr "Групувати за"
+
+#: org/zkoss/ganttz/Planner.java:698
+msgid "Hide reported hours"
+msgstr "Приховати зареєстровані години"
+
+#: org/zkoss/ganttz/data/resourceload/TimeLineRole.java:65
+msgid "Criterion"
+msgstr "Критерій"
+
+#: ganttzk/src/main/resources/web/ganttz/zul/plannerLayout.zul:42
+msgid "Refresh"
+msgstr "Оновити"

--- a/libreplan-webapp/src/main/resources/i18n/uk.po
+++ b/libreplan-webapp/src/main/resources/i18n/uk.po
@@ -1,9272 +1,10060 @@
-# Ukrainian translation for LibrePlan.
+# SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-# Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: LibrePlan\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-10 17:54+0200\n"
-"PO-Revision-Date: 2026-04-22 00:00+0000\n"
+"POT-Creation-Date: 2024-11-27 20:07+0100\n"
+"PO-Revision-Date: 2026-04-23 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: Ukrainian\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: uk\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 
-#: libreplan-webapp/src/main/webapp/qualityforms/qualityForms.zul:22
-msgid "LibrePlan: Quality Forms"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:113
+msgid "Log out"
+msgstr "Вийти"
 
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:58
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:30
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:129
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:45
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:41
-#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:25
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:28
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:33
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:68
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:53
-msgid "Starting date"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:25
+msgid "Create new project"
+msgstr "Створити новий проєкт"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:113
-msgid "project sync info is already being used"
-msgstr ""
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:494
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:504
+msgid "Repeated Project code {0} in Project {1}"
+msgstr "Повторюваний код проєкту {0} у проєкті {1}"
 
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:83
-msgid "Overtime"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:35
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:49
+msgid "First expense"
+msgstr "Перша витрата"
 
-#: libreplan-webapp/src/main/webapp/excetiondays/exceptionDays.zul:22
-msgid "LibrePlan: Calendar Exception Days"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:306
+msgid "criterion type not specified"
+msgstr "тип критерію не вказано"
 
-#: org/libreplan/web/calendars/BaseCalendarModel.java:488
-#: org/libreplan/web/calendars/BaseCalendarModel.java:520
-msgid "This date cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:27
-msgid "Profile data"
-msgstr ""
-
-#: org/libreplan/web/common/components/NewAllocationSelector.java:98
-msgid "specific allocation"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:1088
-msgid ""
-"Periocity cannot be changed because there is already any personal timesheet "
-"stored"
-msgstr ""
-
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:719
-#: org/libreplan/web/planner/company/CompanyPlanningModel.java:352
-msgid "Earned value"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:420
-msgid "criterion codes must be unique inside a criterion  type"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:505
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:76
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:140
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:178
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:32
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:35
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:90
-#: libreplan-webapp/src/main/webapp/planner/order.zul:151
-msgid "Calendar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:31
-msgid "Available hours"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:306
-msgid "Changes have been canceled"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:426
-msgid "criterion names must be unique inside a criterion  type"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:95
-msgid "Invalid value. Default Max Value cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:66
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:73
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:61
-msgid "Last name"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:322
-msgid "{0} \"{1}\" deleted"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1083
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:162
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:168
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:185
-msgid "Some cost category assignments overlap in time"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:40
-msgid "Add stretch"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:403
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:36
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:66
-msgid "Main Settings"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:222
-msgid "Subcategory names must be unique."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:21
-msgid "LibrePlan: Materials Needed At Date"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:630
-msgid "Machines limit reached"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:97
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:125
 msgid "Log in"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1588
-msgid "must be before end date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/components/schedulingStateToggler.zul:32
-msgid "Unschedule"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:161
-msgid "Hours Group"
-msgstr ""
-
-#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:180
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:345
-msgid "Start date cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:349
-msgid "Please select a connector to test it"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:198
-msgid "Expense sheets"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationModel.java:211
-msgid "At least one {0} sequence must be active"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:284
-msgid "Queue-based Resources"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:25
-msgid "Add new configuration unit"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:41
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:77
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:43
-msgid "Categories"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:53
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:28
-msgid "Client"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:72
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:82
-msgid "Progress type"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderModel.java:708
-#: org/libreplan/web/orders/OrderElementTreeController.java:766
-#: org/libreplan/web/planner/TaskElementAdapter.java:888
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:48
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:48
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:38
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:49
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:45
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:58
-msgid "Progress"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:65
-msgid "Default calendar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:41
-msgid "Show all reported hours"
-msgstr ""
-
-#: org/libreplan/web/common/Util.java:675
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:382
-msgid "Remove"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:159
-msgid "Dedication"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:222
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:160
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:182
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:190
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:90
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:183
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:163
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:212
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:171
-msgid "direct link"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:51
-msgid "Average of worked hours in finished applications"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:392
-#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:117
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:164
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:65
-msgid "Hours Types"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:34
-msgid "User settings"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:310
-msgid "Base"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:76
-msgid "Timesheet summary"
-msgstr ""
-
-#: org/libreplan/web/common/IntegrationEntityModel.java:79
-msgid "Could not retrieve Code. Please, try again later"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:33
-msgid "Configuration unit name"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:174
-msgid ""
-"All machine worker assignments must have a start date earlier than the end "
-"date"
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesController.java:391
-msgid "Template cannot be removed because it has applications"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:840
-msgid "format prefix invalid. It cannot be empty or contain whitespaces."
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1319
-msgid "Task contains consolidated progress. Cannot apply sigmoid function."
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:446
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:73
-msgid "Send To Customers"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1154
-msgid "Please, enter a valid effort"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:22
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:26
-msgid "Print configuration"
-msgstr ""
-
-#: org/libreplan/web/planner/limiting/allocation/LimitingResourceAllocationModel.java:222
-msgid "All resources must be queue-based"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:131
-msgid "worker's surname not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:419
-msgid "Application properties"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:50
-#: libreplan-webapp/src/main/webapp/planner/main.zul:61
-msgid "Notes"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:129
-msgid ""
-"Roles of LDAP users cannot be managed because LDAP is enabled and LDAP roles"
-" are being used."
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:317
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:52
-msgid "Virtual Workers"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1305
-msgid "All progress types have already been assigned."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:104
-msgid "Expense properties"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:98
-msgid "Company logo URL"
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersController.java:192
-msgid "Project {0} transfered"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementFilterEnum.java:36
-#: org/libreplan/web/common/components/finders/ResourceAllocationFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/ResourceFilterEnum.java:29
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
-#: org/libreplan/web/common/components/finders/ResourceFilterEnumByResourceAndCriterion.java:31
-msgid "Criterion"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:37
-msgid "Resources capability"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:39
-msgid "material not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:115
-msgid "Resource load view"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:995
-msgid "This worker was already removed by other user"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:133
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:518
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1062
-msgid "Edit {0}: {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:35
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:42
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:53
-msgid "Edit task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:237
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:23
-msgid "Create new Workweek"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:68
-msgid "Progress %"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/Scenario.java:145
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:182
-msgid "name is already used"
-msgstr ""
-
-#: org/libreplan/web/orders/CriterionRequirementWrapper.java:48
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1197
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:229
-msgid "Inherited"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:87
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:35
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:56
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:67
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:438
-#: libreplan-webapp/src/main/webapp/planner/order.zul:105
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:137
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:168
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:58
-msgid "Value"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:142
-msgid "Criterion filter"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:394
-msgid "Role search query"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:259
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:43
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:45
-msgid "Active"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1386
-msgid "Create Template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:93
-msgid "Select start date"
-msgstr ""
-
-#: org/libreplan/web/planner/milestone/AddMilestoneCommand.java:54
-msgid "new milestone"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:251
-msgid ""
-"closckStart:the clockStart must be not null if number of hours is calcultate"
-" by clock"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1359
-msgid "Invalid date. Date must be unique for this Progress Assignment"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:30
-msgid "Associated user"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:191
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:104
-msgid "Existing user"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:406
-msgid "progress type should must be defined if quality form reports progress"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:389
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:171
-msgid "report progress not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:32
-msgid "Set Filter Options"
-msgstr ""
-
-#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:106
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:110
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:100
-msgid "please, select a project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:20
-msgid "LibrePlan: Project Status Report"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:627
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1263
-msgid "You should select a start date for the exception"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:33
-msgid "Show resource assignments"
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersController.java:183
-msgid "Transfer"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:22
-msgid "My tasks"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:896
-msgid "{0} could not be allocated. Cannot allocate more than one resource"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:198
-#: org/libreplan/web/orders/OrderCRUDController.java:967
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:451
-#: org/libreplan/web/materials/MaterialsController.java:291
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:216
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1287
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:210
-msgid "Confirm deleting {0}. Are you sure?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:172
-msgid "Work"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:552
-msgid "init"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:920
-msgid "Select entity, please"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:443
-#: org/libreplan/web/planner/order/SubcontractCommand.java:53
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:69
-msgid "Subcontract"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:290
-msgid "Stretch date must be earlier than End date: "
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:51
-#: libreplan-webapp/src/main/webapp/common/error.zul:55
-msgid "Exit session"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:20
-msgid "LibrePlan: Tim import export info"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:671
-msgid "resources per day cannot be empty or less than zero"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:26
-msgid ""
-"Synchronization order elements with JIRA issues was not completed for the "
-"following reasons:"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:132
-msgid "Activation periods"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:338
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:341
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationController.java:107
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationController.java:110
-msgid "Progress measurements"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1082
-msgid "Sorry, you do not have permissions to access this project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:43
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:43
-msgid "Refresh"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:155
-msgid ""
-"Time period contains non valid data. Ending data must be older than starting"
-" date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:187
-msgid "The field name must be unique."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:99
-msgid "Planning charts expanded"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:28
-msgid "Report structure"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:122
-msgid "Assign selected items"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:119
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:148
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:55
-msgid "Month"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:449
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:66
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:35
-msgid "Capacity"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:463
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:39
-msgid "Hours Worked Per Resource"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:101
-msgid ""
-"Each date must be greater than the dates of the previous task quality form "
-"items."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:67
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:77
-msgid "Version"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:519
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:597
-msgid ""
-"Cannot allocate selected element. There is not any queue that matches "
-"resource allocation criteria at any interval of time"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:43
-msgid ""
-"If you entered the URL directly in the navigation bar of the browser, please"
-" review it or click in the following link in order to go to initial page: "
-msgstr ""
-
-#: org/libreplan/web/reports/ProjectStatusReportController.java:212
-msgid "please, select a criterion"
-msgstr ""
-
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationCommand.java:67
-#: libreplan-webapp/src/main/webapp/planner/order.zul:80
-msgid "Progress consolidation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:116
-msgid "End date communicated by the subcontractor."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:22
-msgid "Companies List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/virtualWorkers.zul:22
-msgid "LibrePlan: Virtual Worker Groups"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/MonteCarloTabCreator.java:51
-#: org/libreplan/web/planner/tabs/MonteCarloTabCreator.java:159
-msgid "MonteCarlo Method"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/ResourceFilterEnum.java:29
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:194
-msgid "Cost category"
-msgstr ""
+msgstr "Увійти"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:714
+msgid "The length must be greater than 0 and not empty"
+msgstr "Довжина повинна бути більше 0 і не порожньою"
+
+#: org/libreplan/web/subcontract/ReportAdvancesController.java:193
+#: org/libreplan/web/subcontract/SubcontractedTasksController.java:202
+msgid "Send"
+msgstr "Надіслати"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:47
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:30
+msgid "Cron expression"
+msgstr "Cron-вираз"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:242
+msgid "Automatic budget"
+msgstr "Автоматичний бюджет"
+
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:20
+msgid "Job Scheduling List"
+msgstr "Список запланованих завдань"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:209
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:91
+msgid "Infinitely Over Assignable"
+msgstr "Необмежено перепризначуваний"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1141
+msgid "Add new progress measurement"
+msgstr "Додати нове вимірювання прогресу"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:184
+msgid "Create new user"
+msgstr "Створити нового користувача"
+
+#: org/libreplan/web/common/BaseCRUDController.java:306
+msgid "Delete {0} \"{1}\". Are you sure?"
+msgstr "Видалити {0} \"{1}\". Ви впевнені?"
+
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:65
+msgid "Dependencies"
+msgstr "Залежності"
+
+#: org/libreplan/web/planner/allocation/GenericAllocationRow.java:55
+msgid "Generic"
+msgstr "Загальний"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:189
+msgid "entity name not specified"
+msgstr "назву сутності не вказано"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1241
+msgid ". Already spent: {0}"
+msgstr ". Вже витрачено: {0}"
+
+#: org/libreplan/web/users/settings/SettingsController.java:172
+msgid "Project since should be lower than project to"
+msgstr "Початок проєкту має бути раніше за кінець проєкту"
+
+#: libreplan-webapp/src/main/webapp/profiles/profiles.zul:23
+msgid "LibrePlan: Profiles"
+msgstr "LibrePlan: Профілі"
 
 #: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:21
 msgid "LibrePlan: Personal timesheet"
-msgstr ""
+msgstr "LibrePlan: Особистий табель"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:264
-msgid "clock finish cannot be empty if number of hours is calcultate by clock"
-msgstr ""
+#: org/libreplan/web/materials/UnitTypeController.java:179
+#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:27
+msgid "Material Unit"
+msgstr "Одиниця виміру матеріалу"
 
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:632
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1179
-#: org/libreplan/web/users/UserCRUDController.java:523
-msgid "left"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:47
+msgid "Personal Data"
+msgstr "Особисті дані"
 
-#: org/libreplan/web/tree/TreeController.java:1025
-msgid "Disabled because of it contains more than one hours group"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:76
+msgid "Dedication chart"
+msgstr "Графік завантаження"
 
-#: org/libreplan/web/common/CustomMenuController.java:520
-msgid "Home"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:88
+msgid "Progress %"
+msgstr "Прогрес %"
 
-#: org/libreplan/web/orders/OrderCRUDController.java:330
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:1090
-msgid "Unsaved changes will be lost. Are you sure?"
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:169
+msgid "Some stretch has higher or equal values than the previous stretch"
 msgstr ""
+"Деякі розтягнення мають значення, більші або рівні попередньому розтягненню"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConfigurationRolesLDAP.java:56
-msgid "LibrePlan role not specified"
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:214
+msgid "Cannot be higher than Ending Date"
+msgstr "Не може бути пізніше за дату завершення"
+
+#: org/libreplan/web/users/OrderAuthorizationController.java:108
+msgid ""
+"Could not add those authorizations to user {0} because they were already "
+"present."
 msgstr ""
+"Не вдалося додати ці авторизації для користувача {0}, оскільки вони вже "
+"існують."
 
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:39
-msgid "Destination scenario"
+#: org/libreplan/web/materials/UnitTypeController.java:126
+#: org/libreplan/web/materials/UnitTypeController.java:146
+#: org/libreplan/web/materials/MaterialsController.java:278
+#: org/libreplan/web/orders/OrderCRUDController.java:1612
+#: org/libreplan/web/orders/OrderCRUDController.java:1628
+#: org/libreplan/web/orders/ProjectDetailsController.java:165
+#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:332
+#: org/libreplan/web/orders/TimSynchronizationController.java:138
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:118
+#: org/libreplan/web/orders/OrderElementTreeController.java:415
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:876
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:888
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1287
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1313
+#: org/libreplan/web/templates/TemplatesTreeController.java:89
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:916
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1080
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1297
+#: org/libreplan/web/users/UserCRUDController.java:462
+#: org/libreplan/web/tree/TreeController.java:295
+#: org/libreplan/web/tree/TreeController.java:1013
+#: org/libreplan/web/common/ConfigurationController.java:1048
+#: org/libreplan/web/common/ConfigurationController.java:1453
+#: org/libreplan/web/montecarlo/MonteCarloController.java:140
+#: org/libreplan/web/montecarlo/MonteCarloController.java:271
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:122
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:123
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:124
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:148
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:153
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:214
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:313
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:337
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:343
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:349
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:378
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:392
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:407
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:419
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:430
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:441
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:473
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:131
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:229
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:342
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:351
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:320
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:325
+#: org/libreplan/web/resources/worker/CriterionsController.java:218
+#: org/libreplan/web/resources/worker/CriterionsController.java:345
+#: org/libreplan/web/resources/worker/CriterionsController.java:354
+#: org/libreplan/web/planner/reassign/ReassignController.java:128
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:44
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:57
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:95
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:97
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:40
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:58
+#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:49
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:35
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:41
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:37
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:98
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:146
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:36
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:81
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:39
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:44
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:55
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:61
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:44
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:62
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:51
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:34
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:44
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:35
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:42
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:51
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:63
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:65
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:43
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:50
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:51
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:62
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:179
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:45
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:53
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:89
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:94
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:58
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:48
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:58
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:64
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:149
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:46
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:74
+msgid "cannot be empty"
+msgstr "не може бути порожнім"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:129
+#: org/libreplan/importers/ExportTimesheetsToTim.java:96
+#: org/libreplan/importers/ExportTimesheetsToTim.java:140
+msgid "Connection values of Tim connector are invalid"
+msgstr "Параметри підключення конектора Tim недійсні"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:109
+msgid "Name of resource"
+msgstr "Назва ресурсу"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:837
+msgid "Periods available depend on resources' calendar."
+msgstr "Доступні періоди залежать від календаря ресурсів."
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:50
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:45
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:85
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:126
+msgid "Unselect"
+msgstr "Зняти вибір"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:68
+msgid "Constraint"
+msgstr "Обмеження"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:162
+msgid "Export product code {0}, project {1}"
+msgstr "Код експорту продукту {0}, проєкт {1}"
+
+#: org/libreplan/web/planner/adaptplanning/AdaptPlanningCommand.java:60
+msgid "Adapt planning according to timesheets"
+msgstr "Адаптувати планування відповідно до табелів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:94
+msgid "quality form item percentage not specified"
+msgstr "відсоток елемента форми якості не вказано"
+
+#: org/libreplan/web/common/CustomMenuController.java:353
+#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:262
+msgid "Calendar Exception Days"
+msgstr "Виняткові дні календаря"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:35
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:31
+msgid "Assigned criteria"
+msgstr "Призначені критерії"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1517
+msgid "Queue-based assignment"
+msgstr "Призначення на основі черги"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:255
+msgid "Schedule Performance Index"
+msgstr "Індекс виконання розкладу"
+
+#: org/libreplan/web/tree/TreeComponent.java:58
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:900
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:35
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:225
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:284
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:306
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:99
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:56
+msgid "Op."
+msgstr "Оп."
+
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:222
+msgid "percentage should be between 1 and 100"
+msgstr "відсоток повинен бути між 1 і 100"
+
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:138
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:49
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:69
+msgid "Company"
+msgstr "Компанія"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:152
+msgid "format sequence code invalid. It must not contain '_'"
+msgstr "формат коду послідовності недійсний. Він не повинен містити '_'"
+
+#: org/libreplan/web/users/UserCRUDController.java:422
+msgid "Confirm edit worker"
+msgstr "Підтвердити редагування працівника"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:78
+msgid "Assign Label"
+msgstr "Призначити мітку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:106
+msgid "default price not specified"
+msgstr "типову ціну не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:416
+msgid ""
+"Number of hours is not properly calculated according to start date and end "
+"date"
 msgstr ""
+"Кількість годин не розраховано належним чином відповідно до дати початку та "
+"дати завершення"
 
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:300
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:429
+msgid ""
+"Progress Assignment cannot be deleted or changed. Progress Assignment "
+"contains Progress Consolidations values"
+msgstr ""
+"Призначення прогресу не можна видалити або змінити. Призначення прогресу "
+"містить значення консолідації прогресу"
+
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:145
+msgid "Date resolved"
+msgstr "Дата вирішення"
+
+#: org/libreplan/web/common/ConfigurationController.java:474
+msgid "Invalid credentials"
+msgstr "Недійсні облікові дані"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:65
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:53
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:52
+msgid "Reference date"
+msgstr "Базова дата"
+
+#: org/libreplan/web/common/BaseCRUDController.java:233
+msgid "{0} \"{1}\" saved"
+msgstr "{0} \"{1}\" збережено"
+
+#: org/libreplan/web/planner/company/CompanyPlanningModel.java:442
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:520
+msgid "Select date"
+msgstr "Обрати дату"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:43
+msgid "Filter timesheet by"
+msgstr "Фільтрувати табель за"
+
+#: org/libreplan/web/common/components/EffortDurationPicker.java:69
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:121
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:187
+msgid "Seconds"
+msgstr "Секунди"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:152
+msgid "Label Type fields"
+msgstr "Поля типу мітки"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:269
+msgid "Money spent"
+msgstr "Витрачені кошти"
+
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:151
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:86
+#: libreplan-webapp/src/main/webapp/common/components/schedulingStateToggler.zul:30
+msgid "Schedule"
+msgstr "Розклад"
+
+#: org/libreplan/web/common/components/finders/OrderInExpenseSheetBandboxFinder.java:44
+#: org/libreplan/web/common/components/finders/OrderElementInExpenseSheetBandboxFinder.java:45
+msgid "Project name (Project code)"
+msgstr "Назва проєкту (Код проєкту)"
+
+#: org/libreplan/web/materials/UnitTypeController.java:184
+#: org/libreplan/web/common/CustomMenuController.java:377
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:199
+msgid "Material Units"
+msgstr "Одиниці виміру матеріалів"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:483
+msgid "it already exists another expense sheet with the same code."
+msgstr "вже існує інший аркуш витрат з таким самим кодом."
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:38
+msgid "Code "
+msgstr "Код "
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:595
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1163
+msgid "Please, select an End Date for the Exception"
+msgstr "Будь ласка, оберіть дату завершення для винятку"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:49
+msgid "Load ratios calculated between"
+msgstr "Коефіцієнти завантаження розраховані між"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:145
+msgid "cost assignment with end date before start date"
+msgstr "призначення витрат з датою завершення раніше за дату початку"
+
+#: org/libreplan/web/materials/MaterialsController.java:247
+#: org/libreplan/web/materials/MaterialsController.java:262
+#: org/libreplan/web/orders/files/OrderFilesController.java:183
+#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:381
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1156
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:819
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1106
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1312
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:400
+#: org/libreplan/web/tree/TreeController.java:1163
+#: org/libreplan/web/tree/TreeController.java:1172
+#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:135
+#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:152
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:293
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:462
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:955
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1196
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:324
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:213
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:385
 #: org/libreplan/web/resources/criterion/CriterionTreeController.java:329
-msgid "Criterion has subelements"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:961
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:280
+#: org/libreplan/web/planner/order/SubcontractController.java:207
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:387
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:629
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:108
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:68
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:72
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:103
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:241
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:79
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:119
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:64
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:57
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:50
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:185
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:41
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:48
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:116
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:54
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:47
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:99
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:43
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:42
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:99
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:46
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:52
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:114
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:87
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:139
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:155
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:45
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:133
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:98
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:140
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:106
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:147
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:119
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:163
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:146
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:188
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:114
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:159
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:202
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:110
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:110
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:153
+msgid "Delete"
+msgstr "Видалити"
 
-#: org/libreplan/web/limitingresources/QueueComponent.java:492
-msgid "Move"
-msgstr ""
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:602
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1170
+msgid "Exception end date should be greater or equals than start date"
+msgstr "Дата завершення винятку має бути більшою або дорівнювати даті початку"
 
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:20
-msgid "LibrePlan: JIRA synchronization info"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:60
+msgid "Upload Project"
+msgstr "Завантажити проєкт"
 
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:31
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:31
-#: org/libreplan/web/planner/TaskElementAdapter.java:896
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:35
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:106
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:51
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:56
-msgid "State"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:124
+msgid "Filter by categories or materials"
+msgstr "Фільтрувати за категоріями або матеріалами"
 
-#: org/libreplan/web/orders/JiraSynchronizationController.java:182
-#: org/libreplan/web/orders/JiraSynchronizationController.java:235
-msgid "Failed: {0}"
-msgstr ""
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:397
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:689
+msgid "Other"
+msgstr "Інше"
 
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:981
-msgid "Delete bound user"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:31
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:79
+msgid "Date raised"
+msgstr "Дата створення"
 
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:132
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:511
-msgid "Connection values of JIRA connector are invalid"
-msgstr ""
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:705
+msgid "Consolidated progress cannot be removed"
+msgstr "Консолідований прогрес не можна видалити"
 
-#: org/libreplan/web/resources/machine/MachineConfigurationController.java:222
-#: org/libreplan/web/resources/worker/CriterionsController.java:239
-msgid "End date is not valid, the new end date must be after start date"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:22
+msgid "Workers List"
+msgstr "Список працівників"
 
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:236
-msgid "Save & New timesheet"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:52
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:71
+msgid "Subcontracting code"
+msgstr "Код субпідряду"
 
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:601
-msgid "Not workable day"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:74
+msgid "hours type"
+msgstr "тип годин"
 
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:22
-msgid "Profiles List"
-msgstr ""
+#: org/libreplan/web/common/CustomMenuController.java:556
+msgid "Project Status"
+msgstr "Статус проєкту"
 
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:21
-msgid "LibrePlan: User access"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:63
+msgid "job group not specified"
+msgstr "групу завдань не вказано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:158
-msgid "label code is already being used"
-msgstr ""
+#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:125
+msgid "Week {0}"
+msgstr "Тиждень {0}"
 
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:22
-msgid "Personal timesheets"
-msgstr ""
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:75
+msgid "Value is not valid, the precision value must not be empty"
+msgstr "Значення недійсне, значення точності не повинно бути порожнім"
 
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:350
-msgid "Create copy"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:463
-msgid "cannot be empty."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:57
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:57
-msgid "Communication Date"
-msgstr ""
-
-#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:117
-msgid "Create task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:299
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:306
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:313
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:320
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:348
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:383
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:390
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:397
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:81
-msgid "Example: {0}"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:220
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:245
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:238
+#: org/libreplan/web/resources/worker/CriterionsController.java:226
 msgid ""
 "Start date is not valid, the new start date must be previous the current "
 "start date"
 msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:92
-msgid "Availability ratio"
-msgstr ""
-
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:526
-msgid "Cost Category"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:167
-msgid "Add new hours group"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:22
-msgid "Progress Types List"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:127
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:512
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1056
-msgid "Create {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:221
-msgid ""
-"Defines the time since last saving operation at project planning "
-"perspectives after which a warning is raised on leaving. Set to 0 in order "
-"to disable the warning."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:113
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:234
-msgid "type of work hours not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:215
-msgid "Seconds planning warning"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLineGroup.java:1114
-msgid "indirect progress assignments should have different types"
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesController.java:377
-msgid "Delete template. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:331
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:1091
-msgid "Confirm exit dialog"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:521
-msgid "User limit reached"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:263
-msgid ""
-"% Deviation interval (difference % between consumed and estimated hours)"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:216
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:241
-msgid "Invalid Start Date. New Start Date must be earlier than End Date"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1677
-msgid "project code already being used"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:33
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:54
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:56
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:37
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:81
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:94
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:55
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:98
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:119
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:53
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:42
-msgid "Start date"
-msgstr ""
-
-#: org/libreplan/web/importers/ProjectImportController.java:79
-#: org/libreplan/web/importers/ProjectImportController.java:98
-msgid "Instance not found."
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1338
-msgid "Value is not valid. It must be smaller than max value"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:164
-msgid "Unexpected: {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:266
-msgid "percentages in quality form items must be unique"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:75
-msgid "Value is not valid, the precision value must not be empty"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/Label.java:47
-msgid "type not specified"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationModel.java:215
-msgid "The {0} sequence prefixes cannot be repeated"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:118
-msgid "Fully, Partially or Unscheduled. (Drag and drop to move tasks)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:50
-msgid "Direct labels"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:759
-#: org/libreplan/web/common/CustomMenuController.java:331
-#: org/libreplan/web/reports/ProjectStatusReportController.java:173
-#: org/libreplan/web/resourceload/ResourceLoadController.java:669
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:144
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:39
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:36
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:32
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:55
-msgid "Criteria"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:67
-msgid "Normal resource allocation"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:449
-msgid "Total Hours"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/AdvancedAllocationTaskController.java:73
-msgid "Some allocations needed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:113
-msgid "Apply filter to"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeModel.java:91
-msgid "Progress type cannot be modified"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:71
-msgid "Total task hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:34
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:29
-msgid "Overload"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:47
-#: libreplan-webapp/src/main/webapp/templates/_advances.zul:38
-msgid "Spread"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:101
-msgid ""
-"Value is not valid, the default max value must be greater than the precision"
-" value "
-msgstr ""
-
-#: org/libreplan/web/common/components/TwoWaySelector.java:68
-msgid "Assigned"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:96
-msgid "Total capacity"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:259
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:727
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1257
-msgid ""
-"Subcontractor values are read only because they were reported by the "
-"subcontractor company."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:265
-msgid "state not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:24
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:24
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:26
-msgid "Select required criteria set and press filter button"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:85
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:145
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:169
-msgid "Concept"
-msgstr ""
-
-#: org/libreplan/web/common/components/TwoWaySelector.java:110
-msgid "Unknown attribute '{0}' in class {1}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:123
-msgid "job group and name are already being used"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:31
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:31
-#: org/libreplan/web/tree/TreeComponent.java:85
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:862
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:26
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:40
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:27
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:49
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:79
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:48
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:29
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:109
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:85
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:26
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:65
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:75
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:51
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:29
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:31
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:54
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:201
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:276
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:42
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:26
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:71
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:37
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:45
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:38
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:50
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:40
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:78
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:93
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:97
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:118
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:88
-#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:37
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:28
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:61
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:82
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:54
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:67
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:158
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:52
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:76
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:173
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:38
-msgid "Code"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:53
-msgid "New entry"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:939
-msgid "Timesheets Template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:200
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:227
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:76
-msgid "Extra Effort"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:150
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:50
-msgid "Year"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:250
-msgid "BCWS"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsController.java:491
-msgid "List of materials for category: {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConfigurationRolesLDAP.java:51
-msgid "role ldap not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:32
-msgid "Synchronization of timesheets was successful"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTree.java:42
-msgid "New template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:44
-msgid "LDAP configuration"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:135
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:49
-msgid "Length"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:80
-msgid "Resources matching selected criteria"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskMilestone.java:121
-msgid "a milestone cannot have a task associated"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:33
-msgid "Overallocated"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:166
-msgid "Company ID already used. It must be unique"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:888
-msgid "Deleting sequence"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:27
-msgid "Work hour type data"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:128
-msgid "the type of work hours name has to be unique. It is already used"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1253
-msgid "Values already sent to the customer. Values cannot be changed "
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:248
-msgid "username is already being used by another user"
-msgstr ""
-
-#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:159
-msgid ""
-"The planning of this task is not in the current scenenario.\n"
-"You should change to any of the following scenarios: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:50
-msgid "Multiple values per resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:43
-#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:50
-msgid "Remove calendar"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:111
-msgid "Deadline (days since project start)"
-msgstr ""
-
-#: org/libreplan/web/orders/CriterionRequirementWrapper.java:45
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1199
-#: org/libreplan/web/workreports/WorkReportQueryController.java:259
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:77
-msgid "Direct"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:28
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:35
-msgid "Job name"
-msgstr ""
-
-#: org/libreplan/web/common/converters/ConverterFactory.java:64
-msgid "Not found converter for {0}"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:186
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:187
-msgid "This criterion type cannot have multiple values in the same period"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLabelTypeAssigment.java:61
-msgid "label type not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeModel.java:53
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:33
-msgid "New task"
-msgstr ""
-
-#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:388
-msgid "Delete item {0}. Are you sure?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:123
-msgid "Supported Chrome, Firefox, Safari and Epiphany browsers"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:206
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:147
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:168
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:176
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:76
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:169
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:149
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:200
-msgid "Output format"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:290
-msgid "last material sequence code not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:27
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:30
-msgid "Relationship"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:109
-msgid "Incorrect authentication"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsController.java:497
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:73
-msgid "List of materials for all categories (select one to filter)"
-msgstr ""
-
-#: org/libreplan/web/resourceload/ResourceLoadModel.java:976
-msgid "Specific Allocations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:61
-msgid "Subcontract price"
-msgstr ""
-
-#: org/libreplan/web/users/settings/PasswordController.java:111
-msgid "Current password is incorrect"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:184
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskDeadlineViolationStatusEnum.java:34
-msgid "No deadline"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:256
-msgid "Virtual resources cannot be bound to any user"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:229
-msgid "Hours cost"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:51
-msgid "Statistics log"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:80
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:90
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:170
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:65
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:82
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:62
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:54
-msgid "Budget"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:48
-msgid "Non-assigned locations"
-msgstr ""
-
-#: org/libreplan/web/users/settings/PasswordController.java:68
-msgid "Password saved"
-msgstr ""
-
-#: org/libreplan/web/labels/LabelTypeCRUDController.java:293
-msgid "Label Type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:303
-msgid "Port"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:119
-msgid "cost assignment's category not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:314
-msgid "last hours cost sequence code not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:127
-msgid "label type name is already in use"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderModel.java:720
-#: org/libreplan/web/orders/OrderElementTreeController.java:746
-#: org/libreplan/web/common/CustomMenuController.java:341
-#: org/libreplan/web/reports/ProjectStatusReportController.java:160
-#: org/libreplan/web/templates/TemplatesTreeController.java:226
-#: org/libreplan/web/planner/TaskElementAdapter.java:915
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:50
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:50
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:148
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:50
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:46
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:76
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:57
-msgid "Labels"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:482
-msgid "Deadline cannot be empty in backwards mode"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:50
-msgid "Zoom level"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:472
-msgid "task is already marked as finished in another timesheet"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:441
-msgid "Normal resource assignment"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:843
-msgid "Finish Hour"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:84
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:324
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:49
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:148
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:67
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:37
-msgid "Password"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_ordersTab.zul:36
-msgid "Cancel editing"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:750
-msgid "Progress that are reported by quality forms cannot be modified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:47
-msgid "Load ratios calculated between"
-msgstr ""
+"Дата початку недійсна, нова дата початку повинна передувати поточній даті "
+"початку"
+
+#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:257
+msgid "Calendar Exception Day"
+msgstr "Винятковий день календаря"
+
+#: org/libreplan/web/resources/worker/CriterionsController.java:242
+#: org/libreplan/web/resources/machine/MachineConfigurationController.java:215
+msgid "End date is not valid, the new end date must be after start date"
+msgstr ""
+"Дата завершення недійсна, нова дата завершення повинна бути після дати "
+"початку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:150
+msgid "username not specified"
+msgstr "ім'я користувача не вказано"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:74
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:84
+msgid "Progress type"
+msgstr "Тип прогресу"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/consolidations/ConsolidatedValue.java:70
 msgid "task end date not specified"
-msgstr ""
+msgstr "дату завершення завдання не вказано"
 
-#: org/libreplan/web/common/components/finders/ExternalCompanyBandboxFinder.java:51
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:29
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:37
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:79
-msgid "ID"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:118
+msgid "Resource load view"
+msgstr "Перегляд завантаження ресурсів"
 
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:114
-msgid "Time tracking"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:45
+msgid "Basic data"
+msgstr "Основні дані"
 
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:69
-msgid "New label"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:69
+msgid "Default calendar"
+msgstr "Типовий календар"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:345
-msgid "UserId"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:39
+msgid "Number of applications"
+msgstr "Кількість застосувань"
 
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:40
-msgid "Company name"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:517
+msgid "You do not have permissions to create new users"
+msgstr "У вас немає дозволів на створення нових користувачів"
 
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:150
-msgid "Add New Label Type Field"
-msgstr ""
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:458
+msgid "effort is not properly calculated based on clock"
+msgstr "трудовитрати не розраховано належним чином на основі годинника"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:282
-msgid "Use LDAP roles"
-msgstr ""
+#: org/libreplan/web/dashboard/DashboardController.java:175
+msgid "No project deadline defined"
+msgstr "Кінцевий термін проєкту не визначено"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:139
-msgid "username not specified"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:175
+msgid "port not specified"
+msgstr "порт не вказано"
 
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:595
-msgid "Expense Sheets"
-msgstr ""
+#: org/libreplan/web/common/CustomMenuController.java:418
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:530
+msgid "Cost Categories"
+msgstr "Категорії витрат"
 
-#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:90
-msgid "Delete expense sheet \"{0}\". Are you sure?"
-msgstr ""
+#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:213
+msgid "changing perspective"
+msgstr "зміна перспективи"
 
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:60
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:36
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:61
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:55
-msgid "First name"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:330
+msgid "passwords do not match"
+msgstr "паролі не збігаються"
 
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:222
-msgid "External code"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:94
+msgid "effort not specified"
+msgstr "трудовитрати не вказано"
 
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:506
-msgid "Manual assignment"
-msgstr ""
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1105
+msgid "Values already sent to the customer. Values cannot be changed "
+msgstr "Значення вже надіслано замовнику. Значення не можна змінити "
 
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:42
-#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:26
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:29
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:69
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:58
-msgid "Ending date"
-msgstr ""
+#: org/libreplan/web/resourceload/ResourceLoadController.java:728
+msgid "Show all elements"
+msgstr "Показати всі елементи"
 
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:79
-msgid "Page up"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:128
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:42
+#: libreplan-webapp/src/main/webapp/planner/main.zul:57
+msgid "End"
+msgstr "Кінець"
 
-#: org/libreplan/importers/ExportTimesheetsToTim.java:106
-msgid "No items found in 'OrderSyncInfo' to export to Tim"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:34
+msgid ""
+"Synchronization of timesheets is not completed for the following reasons:"
+msgstr "Синхронізацію табелів не завершено з таких причин:"
 
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:861
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceType.java:31
-msgid "Queue-based resource"
-msgstr ""
+#: org/libreplan/web/templates/TemplatesTree.java:42
+msgid "New template"
+msgstr "Новий шаблон"
 
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:277
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:125
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:112
-msgid "percentage should be greater than 0% and less than 100%"
-msgstr ""
+#: org/libreplan/web/planner/company/CompanyPlanningModel.java:538
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:849
+msgid "h"
+msgstr "год"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:122
-msgid "Check for updates"
-msgstr ""
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:234
+msgid "item"
+msgstr "елемент"
 
-#: org/libreplan/web/users/settings/SettingsController.java:135
-msgid "Settings saved"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:255
+msgid "Seconds planning warning"
+msgstr "Попередження про планування секунд"
 
-#: org/libreplan/web/labels/LabelTypeCRUDController.java:298
-msgid "Label Types"
-msgstr ""
+#: org/libreplan/web/orders/CriterionRequirementWrapper.java:216
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:108
+msgid "Validate"
+msgstr "Підтвердити"
 
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1227
-msgid "inherited exception can not be removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:30
-msgid "Machine data"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:345
-msgid "Confirm remove user"
-msgstr ""
-
-#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:263
-#: org/libreplan/web/common/CustomMenuController.java:327
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:54
-msgid "Calendar Exception Days"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:24
-msgid "Create new project"
-msgstr ""
-
-#: org/libreplan/web/materials/UnitTypeController.java:181
-#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:27
-msgid "Material Unit"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:139
-msgid "Cannot create another progress of the same type"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:301
-#: org/libreplan/web/common/CustomMenuController.java:543
-#: org/libreplan/web/templates/OrderTemplatesController.java:303
-#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:142
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:47
-msgid "Planning"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:42
-msgid "Template Tree"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:29
-msgid "External overload"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:250
-msgid "Parent"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:29
-msgid "Add new progress assignment"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:34
-msgid "Work record"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:173
-msgid "Heading Fields"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarModel.java:534
-msgid "Date cannot include the entire next work week"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:29
-msgid "Managing fields and labels"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:182
-msgid "Violated deadline"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:126
-msgid "Enable/Disable warning about new LibrePlan versions available"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/HoursGroup.java:186
-msgid "working hours not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:73
-msgid "Hours type for personal timesheets"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:31
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:53
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:67
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineGroupTemplate.java:273
-msgid "Group"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationCommand.java:47
-msgid "Advanced allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:45
-msgid "Connectors"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:530
-msgid "Select for automatic queuing"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:182
-msgid "Order-element for \"{0}\" issue not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:147
-msgid "Scheduling mode"
-msgstr ""
-
-#: org/libreplan/web/subcontract/ReportAdvancesController.java:207
-msgid "Progress sent successfully"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/userDashboard.zul:21
-msgid "LibrePlan: My Dashboard"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:131
-msgid "Work week"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:250
-msgid "Budgeted Cost Work Scheduled"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:125
-msgid "Expense lines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:145
-msgid "Label Type fields"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:22
-#: libreplan-webapp/src/main/webapp/common/error.zul:21
-msgid "LibrePlan: Runtime Error"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:152
-#: libreplan-webapp/src/main/webapp/common/components/schedulingStateToggler.zul:29
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:77
-msgid "Schedule"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:243
+msgid "task cannot be empty if it is shared by lines"
+msgstr "завдання не може бути порожнім, якщо воно є спільним для рядків"
 
 #: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:84
 msgid "quality form name not specified"
-msgstr ""
+msgstr "назву форми якості не вказано"
 
-#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:112
-msgid "Hours Type"
-msgstr ""
+#: org/libreplan/web/limitingresources/QueueComponent.java:223
+msgid "Task: {0}"
+msgstr "Завдання: {0}"
 
-#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/OrderVersion.java:55
-msgid "owner scenario not specified"
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:235
+msgid "a personal expense sheet must have the same resource in all the lines"
 msgstr ""
+"особистий аркуш витрат повинен мати один і той самий ресурс у всіх рядках"
 
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:78
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:27
-msgid "Allocation configuration"
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:396
+msgid "Test LDAP connection"
+msgstr "Перевірити з'єднання LDAP"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:28
+msgid "Calendar data"
+msgstr "Дані календаря"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:62
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:69
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:82
+msgid "Last name"
+msgstr "Прізвище"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:165
+msgid "Task should start job"
+msgstr "Завдання має запускати роботу"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:369
+msgid "Delete template. Are you sure?"
+msgstr "Видалити шаблон. Ви впевнені?"
+
+#: org/libreplan/web/common/CustomMenuController.java:532
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:39
+msgid "Estimated/Planned Hours Per Task"
+msgstr "Оцінені/заплановані години за завданням"
+
+#: org/libreplan/web/reports/ProjectStatusReportController.java:215
+msgid "please, select a criterion"
+msgstr "будь ласка, оберіть критерій"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:185
+msgid ""
+"Giving a gift today means LibrePlan continues to remain available and in "
+"active development tomorrow!"
 msgstr ""
+"Зробити подарунок сьогодні означає, що LibrePlan залишатиметься доступним та "
+"активно розвиватиметься завтра!"
+
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:36
+msgid "Project Status Report"
+msgstr "Звіт про статус проєкту"
+
+#: libreplan-webapp/src/main/webapp/common/accessForbidden.zul:40
+msgid ""
+"Please try to contact with any administrator in order to review your "
+"permissions in LibrePlan."
+msgstr ""
+"Будь ласка, спробуйте зв'язатися з адміністратором для перевірки ваших "
+"дозволів у LibrePlan."
+
+#: libreplan-webapp/src/main/webapp/common/jobScheduling.zul:20
+msgid "LibrePlan: Job Scheduling"
+msgstr "LibrePlan: Планування завдань"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:77
+msgid "Hour costs"
+msgstr "Вартість годин"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:137
+msgid "[generic all workers]"
+msgstr "[загальний — усі працівники]"
+
+#: org/libreplan/web/dashboard/CostStatusController.java:115
+#: org/libreplan/web/users/dashboard/MyTasksAreaController.java:73
+#: org/libreplan/web/users/dashboard/MyTasksAreaController.java:74
+msgid "{0} h"
+msgstr "{0} год"
+
+#: org/libreplan/web/resourceload/ResourceLoadController.java:228
+#: org/libreplan/web/planner/company/CompanyPlanningModel.java:347
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:704
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:49
+msgid "Load"
+msgstr "Завантаження"
+
+#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:308
+#: org/libreplan/web/planner/reassign/Type.java:31
+msgid "All project tasks"
+msgstr "Усі завдання проєкту"
+
+#: libreplan-webapp/src/main/webapp/logs/_logsFilter.zul:26
+msgid "Apply filtering to issues"
+msgstr "Застосувати фільтрацію до проблем"
+
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:29
+msgid "Inherits from date"
+msgstr "Успадковує з дати"
+
+#: org/libreplan/web/common/entrypoints/EntryPointsHandler.java:97
+msgid "{0} annotation required on {1}"
+msgstr "{0} анотація потрібна для {1}"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:182
+msgid "Ever!"
+msgstr "Назавжди!"
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:482
+msgid "Queue-based resource assignation"
+msgstr "Розподіл ресурсів на основі черги"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:160
+msgid "New user"
+msgstr "Новий користувач"
+
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:574
+msgid "Machine"
+msgstr "Машина"
+
+#: org/libreplan/web/workreports/WorkReportQueryController.java:372
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:122
+msgid "Tasks"
+msgstr "Завдання"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:710
+#: org/libreplan/web/workreports/WorkReportQueryController.java:336
+msgid "You do not have permissions to edit this timesheet"
+msgstr "У вас немає дозволів на редагування цього табелю"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:104
+msgid "Name of project"
+msgstr "Назва проєкту"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:79
+msgid "type"
+msgstr "тип"
+
+#: libreplan-business/src/main/java/org/libreplan/business/requirements/entities/IndirectCriterionRequirement.java:77
+msgid "parent not specified"
+msgstr "батьківський елемент не вказано"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:127
+msgid "Unbound resource"
+msgstr "Непризначений ресурс"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:47
+msgid "Date last progress reported"
+msgstr "Дата останнього звіту про прогрес"
+
+#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:59
+msgid "START"
+msgstr "СТАРТ"
+
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:32
+msgid "Expense Sheets List"
+msgstr "Список аркушів витрат"
+
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:21
+msgid "LibrePlan: Change password"
+msgstr "LibrePlan: Зміна пароля"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:33
+msgid "Assigned criterion requirements"
+msgstr "Призначені вимоги критеріїв"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:331
+msgid "Scheduling saved"
+msgstr "Планування збережено"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:115
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:123
+msgid "Non Consolidated"
+msgstr "Неконсолідований"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:193
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:48
+msgid "Year"
+msgstr "Рік"
+
+#: org/libreplan/web/common/CustomMenuController.java:318
+#: org/libreplan/web/importers/ProjectImportController.java:84
+msgid "Import project"
+msgstr "Імпортувати проєкт"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardforglobal.zul:32
+msgid "Pipeline"
+msgstr "Конвеєр"
+
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:22
+msgid "Users List"
+msgstr "Список користувачів"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:84
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:152
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:180
+msgid "Concept"
+msgstr "Концепція"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:870
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:121
+msgid "Start hour"
+msgstr "Час початку"
+
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:52
+msgid "Apply filtering to resources satisfying required criteria"
+msgstr "Застосувати фільтрацію до ресурсів, що відповідають вимогам критеріїв"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:481
+msgid "Assign element to queue automatically"
+msgstr "Автоматично призначити елемент до черги"
+
+#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:121
+msgid "Create task"
+msgstr "Створити завдання"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:77
+msgid "Hours type for personal timesheets"
+msgstr "Тип годин для особистих табелів"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1097
+msgid "Calculated progress measurements cannot be removed"
+msgstr "Розраховані вимірювання прогресу не можна видалити"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:59
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:38
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:38
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:171
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:94
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:180
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:185
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:202
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:226
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:242
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:172
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:192
+msgid "Show"
+msgstr "Показати"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:349
+msgid "the cost category name has to be unique and it is already in use"
+msgstr ""
+"назва категорії витрат повинна бути унікальною, і вона вже використовується"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:467
+msgid "Role property"
+msgstr "Властивість ролі"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:71
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:185
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:104
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:119
+msgid "task not specified"
+msgstr "завдання не вказано"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:106
+msgid "No items found in 'OrderSyncInfo' to export to Tim"
+msgstr "Не знайдено елементів в 'OrderSyncInfo' для експорту до Tim"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:249
+msgid "BAC"
+msgstr "BAC"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:154
+msgid "Cannot create another progress of the same type"
+msgstr "Неможливо створити інший прогрес того самого типу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:432
+msgid "currency symbol not specified"
+msgstr "символ валюти не вказано"
+
+#: org/libreplan/importers/notifications/ComposeMessage.java:193
+msgid " - this user have not filled E-mail"
+msgstr " - цей користувач не заповнив електронну пошту"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:168
+msgid "Imputed hours"
+msgstr "Зафіксовані години"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:164
+msgid "company code cannot contain whitespaces"
+msgstr "код компанії не може містити пробіли"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:224
+msgid "progress type marked as quality form but is updatable"
+msgstr "тип прогресу позначений як форма якості, але є оновлюваним"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:46
+msgid "Apply changes and go back to scheduling"
+msgstr "Застосувати зміни та повернутися до планування"
+
+#: org/libreplan/web/scenarios/TransferOrdersModel.java:144
+msgid "Please select a source scenario"
+msgstr "Будь ласка, оберіть вихідний сценарій"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:52
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:54
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:56
+msgid "Probability %"
+msgstr "Ймовірність %"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:124
+msgid "Any"
+msgstr "Будь-який"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:163
+msgid "Doing {0} reassignations"
+msgstr "Виконується {0} перепризначень"
+
+#: org/libreplan/web/calendars/BaseCalendarModel.java:508
+msgid "This date can not include the whole previous work week"
+msgstr "Ця дата не може охоплювати весь попередній робочий тиждень"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:873
+msgid "Timesheets Template"
+msgstr "Шаблон табелів"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:606
+msgid "Personal"
+msgstr "Особистий"
+
+#: org/libreplan/web/dashboard/DashboardController.java:171
+msgid "There is a margin of {0} days with the project global deadline ({1}%)."
+msgstr "Є запас у {0} днів до загального кінцевого терміну проєкту ({1}%)."
+
+#: org/libreplan/web/materials/MaterialsModel.java:179
+#: org/libreplan/web/calendars/BaseCalendarModel.java:602
+#: org/libreplan/web/scenarios/ScenarioModel.java:220
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:190
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:204
+#: org/libreplan/web/labels/LabelTypeModel.java:154
+#: org/libreplan/web/labels/LabelTypeModel.java:180
+#: org/libreplan/web/labels/LabelTypeCRUDController.java:262
+msgid "{0} already exists"
+msgstr "{0} вже існує"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:224
+msgid "maximum value of percentagee progress type must be 100"
+msgstr ""
+"максимальне значення відсоткового типу прогресу повинно дорівнювати 100"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1626
+msgid "Confirm change"
+msgstr "Підтвердити зміну"
+
+#: org/libreplan/web/common/CustomMenuController.java:468
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:335
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:33
+msgid "Configuration"
+msgstr "Конфігурація"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:453
+msgid "Assign element to queue manually"
+msgstr "Вручну призначити елемент до черги"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:577
+msgid "Please, select type of exception"
+msgstr "Будь ласка, оберіть тип винятку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:377
+msgid "deadline must be after start date"
+msgstr "кінцевий термін має бути після дати початку"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1021
+msgid "Efforts"
+msgstr "Трудовитрати"
+
+#: org/libreplan/web/common/ConfigurationController.java:973
+msgid "format prefix invalid. It cannot be empty or contain whitespaces."
+msgstr ""
+"формат префікса недійсний. Він не може бути порожнім або містити пробіли."
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:22
+msgid "LibrePlan: Settings"
+msgstr "LibrePlan: Налаштування"
+
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:110
+msgid "Expense properties"
+msgstr "Властивості витрат"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:749
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:214
+msgid "Personal timesheet saved"
+msgstr "Особистий табель збережено"
+
+#: org/libreplan/web/montecarlo/MonteCarloModel.java:68
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:71
+msgid "Critical path"
+msgstr "Критичний шлях"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:81
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:245
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:30
+msgid "Add new row"
+msgstr "Додати новий рядок"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:263
+msgid "username is already being used by another user"
+msgstr "ім'я користувача вже використовується іншим користувачем"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:149
+msgid "Resource removed from task job"
+msgstr "Ресурс видалено з роботи завдання"
+
+#: libreplan-webapp/src/main/webapp/orders/_ordersTab.zul:37
+msgid "Cancel editing"
+msgstr "Скасувати редагування"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:204
+msgid "default password was not changed"
+msgstr "типовий пароль не було змінено"
+
+#: org/libreplan/web/common/CustomMenuController.java:493
+msgid "Received From Customers"
+msgstr "Отримано від замовників"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:155
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:60
+msgid "Role name"
+msgstr "Назва ролі"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:35
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:56
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:29
+msgid "Label type"
+msgstr "Тип мітки"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1285
+msgid "Stretches with Interpolation"
+msgstr "Розтягнення з інтерполяцією"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:44
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:49
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:44
+msgid "Dates"
+msgstr "Дати"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:71
+msgid "E-mail subject"
+msgstr "Тема листа"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:447
+msgid "Role search strategy"
+msgstr "Стратегія пошуку ролей"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:23
+msgid "LibrePlan: Timesheets"
+msgstr "LibrePlan: Табелі"
+
+#: libreplan-webapp/src/main/webapp/costcategories/costCategory.zul:23
+msgid "LibrePlan: Cost Categories"
+msgstr "LibrePlan: Категорії витрат"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:227
+msgid "date cannot be empty if it is shared by lines"
+msgstr "дата не може бути порожньою, якщо вона є спільною для рядків"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:98
+msgid ""
+"Each date must be greater than the dates of the previous task quality form "
+"items."
+msgstr ""
+"Кожна дата повинна бути більшою за дати попередніх елементів форми якості "
+"завдання."
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:423
+msgid "currency code not specified"
+msgstr "код валюти не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:112
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:277
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:125
+msgid "percentage should be greater than 0% and less than 100%"
+msgstr "відсоток повинен бути більше 0% і менше 100%"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:27
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:47
+msgid "Company ID"
+msgstr "Ідентифікатор компанії"
+
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:31
+msgid "Personal details"
+msgstr "Особисті відомості"
+
+#: org/libreplan/web/common/components/EffortDurationPicker.java:63
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:127
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:188
+msgid "Minutes"
+msgstr "Хвилини"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:179
+msgid "The same resource is assigned twice inside an interval"
+msgstr "Один і той самий ресурс призначено двічі в межах інтервалу"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:35
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:48
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:55
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:58
+msgid "from"
+msgstr "від"
+
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:43
+msgid "Change password"
+msgstr "Змінити пароль"
+
+#: org/libreplan/web/common/JobSchedulerController.java:267
+#: org/libreplan/web/common/JobSchedulerController.java:268
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:451
+msgid "Manual"
+msgstr "Вручну"
+
+#: org/libreplan/web/dashboard/DashboardController.java:184
+msgid "On schedule"
+msgstr "За розкладом"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:268
+msgid "clock finish cannot be empty if number of hours is calcultate by clock"
+msgstr ""
+"час завершення за годинником не може бути порожнім, якщо кількість годин "
+"розраховується за годинником"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:32
+msgid "Queue Element Information"
+msgstr "Інформація про елемент черги"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:57
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:57
+msgid "Communication Type"
+msgstr "Тип комунікації"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:451
+#: org/libreplan/web/common/BaseCRUDController.java:129
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1021
+msgid "Create {0}"
+msgstr "Створити {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:109
+msgid "progress assignment not specified"
+msgstr "призначення прогресу не вказано"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:183
+msgid "But"
+msgstr "Але"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:325
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1007
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1052
+msgid ""
+"Progress Measurement cannot be deleted. Progress Measurement already "
+"consolidated"
+msgstr ""
+"Вимірювання прогресу не можна видалити. Вимірювання прогресу вже "
+"консолідовано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:296
+msgid "The hour cost codes must be unique."
+msgstr "Коди вартості годин повинні бути унікальними."
+
+#: org/libreplan/web/common/components/finders/UserBandboxFinder.java:46
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:27
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:48
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:56
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:170
+msgid "Username"
+msgstr "Ім'я користувача"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:107
+msgid "Search"
+msgstr "Пошук"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:55
+msgid "Hierarchy"
+msgstr "Ієрархія"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:35
+msgid "Communications To Subcontractors"
+msgstr "Комунікації до субпідрядників"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:602
+msgid "A description field with the same name already exists."
+msgstr "Поле опису з такою самою назвою вже існує."
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:156
+msgid "Label filter"
+msgstr "Фільтр міток"
+
+#: org/libreplan/web/workreports/WorkReportModel.java:579
+msgid "Show all"
+msgstr "Показати всі"
+
+#: org/libreplan/web/common/ConfigurationController.java:1044
+msgid "Select entity, please"
+msgstr "Будь ласка, оберіть сутність"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:562
+msgid "Not workable day"
+msgstr "Неробочий день"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:29
+msgid "Export options"
+msgstr "Параметри експорту"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:95
+msgid ""
+"Estimated start date for the task (press enter in textbox to open calendar "
+"popup or type in date directly)"
+msgstr ""
+"Орієнтовна дата початку завдання (натисніть Enter у текстовому полі, щоб "
+"відкрити спливаючий календар, або введіть дату безпосередньо)"
+
+#: org/libreplan/web/resources/machine/MachineConfigurationController.java:124
+msgid "No worker selected"
+msgstr "Працівника не обрано"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:300
+msgid "to {0}"
+msgstr "до {0}"
+
+#: org/libreplan/web/materials/MaterialsController.java:335
+msgid "Cannot insert material in general view. Please, select a category"
+msgstr ""
+"Неможливо вставити матеріал у загальному вигляді. Будь ласка, оберіть "
+"категорію"
+
+#: org/libreplan/web/dashboard/DashboardController.java:237
+msgid ""
+"Days Interval (Calculated as task completion end date minus estimated end "
+"date)"
+msgstr ""
+"Інтервал днів (розраховується як дата завершення завдання мінус орієнтовна "
+"дата завершення)"
 
 #: org/libreplan/web/resources/criterion/CriterionAdminController.java:96
 msgid ""
 "Disable hierarchy will cause criteria tree to be flattened. Are you sure?"
 msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1570
-msgid "Configure"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:26
-msgid "Profiles authorization"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:90
-msgid "Company password"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionAdminController.java:205
-msgid "Criterion Types"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:125
-msgid "Show a notification when new LibrePlan versions are released"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:900
-msgid "Index fields and labels must be unique and consecutive"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:45
-msgid "Export to Tim"
-msgstr ""
-
-#: org/libreplan/web/common/TemplateModel.java:348
-msgid "{0} projects remaining to reassign"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:331
-msgid "passwords do not match"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:22
-msgid "Calendars List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:73
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:77
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:62
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:43
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:62
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:98
-msgid "Filter by projects"
-msgstr ""
-
-#: org/libreplan/web/montecarlo/MonteCarloController.java:163
-msgid "Number of iterations should be between 1 and {0}"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:540
-msgid "it already exists another expense sheet with the same code."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:44
-msgid "Details"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:443
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:35
-msgid "Alpha"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:273
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:133
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:143
-msgid "Two Hour Cost of the same type overlap in time"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLabelTypeAssigment.java:64
-msgid "default label not specified"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioCRUDController.java:133
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:333
-msgid "Create derived"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:48
-msgid "units not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:22
-msgid "LibrePlan: Progress Types"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:36
-msgid "MonteCarlo chart"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:523
-msgid "Preferences"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:25
-msgid "is not completed for the following reasons:"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:85
-msgid "Our company username"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioModel.java:118
-msgid "You cannot remove the default scenario \"{0}\""
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:149
-msgid "Resources load since"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderElementTemplate.java:483
-msgid "template name is already in use"
-msgstr ""
-
-#: org/libreplan/web/subcontract/ReportAdvancesModel.java:226
-#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:250
-#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:296
-msgid "Error: {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:84
-msgid "maximum value not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:22
-msgid "Machines List"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1396
-#: org/libreplan/web/orders/OrderElementTreeController.java:336
-msgid "Not enough permissions to create templates"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:142
-msgid "The browser you are using"
-msgstr ""
-
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:181
-msgid "This resource has already been added."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:108
-msgid "user"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:39
-msgid "Sync with JIRA"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:32
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:38
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:108
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:53
-msgid "Task name"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:34
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:36
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:25
-msgid "Cost category assignment"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:281
-msgid "Task Status"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:50
-msgid "Value last progress measurement"
-msgstr ""
-
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:161
-msgid "must be after end date"
-msgstr ""
-
-#: org/libreplan/web/common/components/EffortDurationPicker.java:69
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:103
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:144
-msgid "Seconds"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:664
-msgid "Personal"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:170
-msgid "No project deadline defined"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:95
-msgid "Responsible"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:91
-msgid "Available materials"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:58
-msgid "Help on authentication (opens a new window)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:42
-msgid "Filter timesheet by"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:210
-msgid "MonteCarlo method"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:43
-#: libreplan-webapp/src/main/webapp/templates/_advances.zul:37
-msgid "Max value"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:410
-msgid "LibrePlan Role"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeController.java:1138
-msgid "Value is not valid in current list of Hours Group"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:117
-msgid ""
-"Enable/Disable autocomplete property in login form, if the admin password is"
-" still the default one"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:277
-msgid "Start hour cannot be greater than finish hour"
-msgstr ""
-
-#: org/libreplan/web/common/TemplateController.java:243
-msgid "A new version "
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:615
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:32
-msgid "Personal timesheet"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:389
-msgid "Amount work percentage should be between 0 and 100"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:40
-msgid "Work done"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:122
-msgid "Complementary text fields"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:55
-msgid "Remaining time"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:129
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:514
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1058
-msgid "Create {0}: {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:55
-msgid "Maximum/minimum of estimated hours"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:114
-#: org/libreplan/web/users/UserCRUDController.java:115
-#: org/libreplan/web/users/UserCRUDController.java:405
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:156
-msgid "Yes"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:126
-msgid "external company not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:108
-#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:126
-msgid "Dashboard"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:379
-msgid "Group path"
-msgstr ""
-
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:253
-msgid "percentage should be between 1 and 100"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:23
-msgid "LibrePlan: Timesheet Lines List"
-msgstr ""
-
-#: org/libreplan/web/labels/LabelTypeModel.java:269
-msgid "Already exists other label with the same name"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:96
-#: org/libreplan/importers/ExportTimesheetsToTim.java:140
-#: org/libreplan/importers/ImportRosterFromTim.java:129
-msgid "Connection values of Tim connector are invalid"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:841
-msgid ""
-"Periods available depend on the satisfaction of the criteria of resources "
-"and their calendars."
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:850
-msgid "Resources per day are zero"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:124
-msgid "Project progress percentage"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:254
-msgid "Valid until"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/Label.java:44
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:50
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:527
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Connector.java:70
-#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/Scenario.java:114
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:158
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:116
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:97
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:195
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderElementTemplate.java:373
-msgid "name not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:87
-msgid "key not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector_combo.zul:25
-msgid "Select criteria or resources"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:71
-msgid "Assignation"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:302
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:513
-msgid ""
-"Progress Assignment cannot be deleted or changed. Progress Assignment "
-"contains Progress Consolidations values"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:590
-msgid "Expense Sheet"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:638
-msgid "{0} cannot be fulfilled"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:29
-msgid "Inherits from date"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:126
-msgid "values are not valid, the values must not be null"
-msgstr ""
-
-#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:306
-#: org/libreplan/web/planner/reassign/Type.java:31
-msgid "All project tasks"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:948
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:84
-msgid "Function"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:59
-msgid "Authorizations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:27
-msgid "with"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:123
-msgid "Projects view filtering"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:29
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:39
-#: libreplan-webapp/src/main/webapp/orders/_synchronizationInfo.zul:24
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:187
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:85
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:113
-msgid "Close"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:969
-msgid ""
-"Cannot delete timesheet template. There are some timesheets bound to it."
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:213
-msgid "Completed: {0}%"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:136
-msgid "default calendar not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:380
-msgid "You have exceeded the maximum limit of users"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:21
-msgid "LibrePlan: Work And Progress Per Project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:42
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:30
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:42
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:58
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:52
-msgid "to"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:51
-msgid "View"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:63
-msgid "By critical path duration"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:190
-msgid "Doing {0} reassignations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:79
-msgid "Material assignments"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:194
-msgid "Estimated time for \"{0}\" issue is 0"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:69
-msgid "Main menu"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:50
-msgid "Default max value"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:204
-msgid "Origin"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:819
-msgid "Unallocated name"
-msgstr ""
-
-#: org/libreplan/web/orders/JiraSynchronizationController.java:302
-msgid "Start sync"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:324
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:170
-msgid "last hours group sequence code not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:280
-msgid "Enable LDAP authentication"
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:210
-msgid "No roster-exceptions found in the response"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:22
-msgid "LibrePlan: Calendars"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:192
-msgid "entity name not specified"
-msgstr ""
-
-#: org/libreplan/web/common/components/TwoWaySelector.java:79
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:576
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:585
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:593
-msgid "Unassigned"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:457
-msgid "You do not have permissions to go to edit worker window"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:44
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:45
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:46
-msgid "Subcontracting date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/job_scheduling.zul:20
-msgid "LibrePlan: Job Scheduling"
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:182
-msgid "No valid response for department \"{0}\""
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:251
-msgid "ACWP"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:223
-msgid "Allocation: [{0},{1}]"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:303
-msgid "Derived of calendar {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:30
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:50
-msgid "Assignment log"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:351
-msgid "Unable to parse cron expression"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:257
-msgid "VAC"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:140
-msgid "The expense sheet line codes must be unique."
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:510
-msgid "Project Status"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:55
-msgid "Hierarchy"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:47
-msgid "Estimated hours average"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:312
-msgid "Delete {0} \"{1}\". Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1735
-msgid "It already exists a end date with the same date. "
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:117
-msgid "Tasks input buffer"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:46
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:27
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:40
-msgid "Criterion name"
-msgstr ""
-
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:321
-msgid ""
-"Quality form should include an item with a value of 100% in order to report "
-"progress"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:153
-msgid "company code cannot contain whitespaces"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:170
-msgid "please, select a quality form"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:248
-msgid "Queue-based resources cannot be bound to any user"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:764
-msgid "Consolidated progress cannot be removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:48
-msgid "Both calendars and gantt charts"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:364
-msgid "Authorization"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:158
-msgid "Effort"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/MyTasksAreaController.java:75
-#: org/libreplan/web/dashboard/CostStatusController.java:118
-msgid "{0} h"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:41
-msgid "Apply changes and go back to scheduling"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:30
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:35
-msgid "Superuser"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:194
-msgid "Percentage of estimated budget in money / money spent"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:330
-msgid "Test LDAP connection"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:258
-msgid "Estimate To Complete"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:502
-msgid "must be greater or equal than 0"
-msgstr ""
+"Вимкнення ієрархії призведе до вирівнювання дерева критеріїв. Ви впевнені?"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1381
+msgid "Create Template"
+msgstr "Створити шаблон"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:60
+msgid "By critical path hours"
+msgstr "За годинами критичного шляху"
+
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:31
+msgid "Next fire time"
+msgstr "Наступний час запуску"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:496
+msgid "task is already marked as finished in another timesheet"
+msgstr "завдання вже позначено як завершене в іншому табелі"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:42
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:66
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:176
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:26
+msgid "Profile name"
+msgstr "Назва профілю"
+
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:28
+msgid "Profile data"
+msgstr "Дані профілю"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:864
+msgid "New project version"
+msgstr "Нова версія проєкту"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:28
+msgid "Add new progress assignment"
+msgstr "Додати нове призначення прогресу"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:31
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:53
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:68
+msgid "Group"
+msgstr "Група"
+
+#: org/libreplan/web/scenarios/TransferOrdersController.java:181
+msgid "Transfer"
+msgstr "Перенесення"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:133
+msgid "Prevention"
+msgstr "Запобігання"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:324
+msgid "Activation"
+msgstr "Активація"
+
+#: org/libreplan/web/common/JobSchedulerController.java:385
+msgid "Job is scheduled/unscheduled"
+msgstr "Завдання заплановане/незаплановане"
+
+#: org/libreplan/web/scenarios/ScenarioModel.java:219
+msgid "Could not save the scenario"
+msgstr "Не вдалося зберегти сценарій"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:171
+msgid "Finished"
+msgstr "Завершено"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:313
+msgid "Reassign"
+msgstr "Перепризначити"
+
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:63
+msgid "Queue-based resource allocation"
+msgstr "Розподіл ресурсів на основі черги"
+
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:27
+msgid "Heading"
+msgstr "Заголовок"
+
+#: org/libreplan/web/common/CustomMenuController.java:473
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:143
+msgid "Companies"
+msgstr "Компанії"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:192
+msgid "Create exception"
+msgstr "Створити виняток"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:69
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:78
+#: org/libreplan/web/common/components/EffortDurationPicker.java:62
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:882
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:38
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:34
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:170
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:37
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:133
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:189
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:37
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:127
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:77
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:55
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:92
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:34
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:80
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:89
+msgid "Hours"
+msgstr "Години"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:47
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:63
+#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:45
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:107
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:59
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:46
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:65
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:52
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:181
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:63
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:56
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:82
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:61
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:50
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:76
+msgid "Generate code"
+msgstr "Згенерувати код"
+
+#: org/libreplan/web/users/ProfileCRUDController.java:128
+#: org/libreplan/web/common/CustomMenuController.java:451
+msgid "Profiles"
+msgstr "Профілі"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:26
+msgid "Assigned locations"
+msgstr "Призначені місця"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:396
+msgid " hours"
+msgstr " год"
 
 #: org/libreplan/importers/JiraTimesheetSynchronizer.java:148
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:290
-msgid "No worklog items found for \"{0}\" issue"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/order.zul:89
-#: libreplan-webapp/src/main/webapp/planner/order.zul:95
-msgid "Check consolidated progresses"
-msgstr ""
-
-#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:136
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:179
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:313
-#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:174
-#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:131
-msgid "Label has already been added."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:37
-msgid "Filter timesheet lines by"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:21
-msgid "LibrePlan: Material Units"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:64
-msgid "New Template element"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:358
-msgid "Expand/Collapse all"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:37
-msgid "Warning: Not editing from home page of bound users"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:533
-msgid "last criterion sequence code not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:43
-msgid "Number of finished applications"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:22
-msgid "Projects list"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:453
-msgid "Create Worker"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:27
-msgid "Type name"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderTemplate.java:71
-msgid "template calendar not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SubcontractController.java:154
-msgid "It already exists a deliver date with the same date. "
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:111
-msgid "total must be greater or equal than 0"
-msgstr ""
-
-#: org/libreplan/web/common/components/ResourceAllocationBehaviour.java:63
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:38
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:39
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:86
-msgid "Queue-based"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:131
-msgid "must be a real positive number"
-msgstr ""
-
-#: org/libreplan/web/common/TemplateModel.java:344
-msgid "Reassigning {0} projects"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:452
-msgid "Only {0} resources per day were achieved for current allocation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:95
-msgid "effort not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1288
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:199
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:328
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:401
-#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:389
-#: org/libreplan/web/orders/OrderCRUDController.java:1355
-#: org/libreplan/web/orders/OrderCRUDController.java:1790
-#: org/libreplan/web/tree/TreeController.java:1162
-#: org/libreplan/web/tree/TreeController.java:1168
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:452
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:894
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1214
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1461
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:970
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:324
-#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:143
-#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:162
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:287
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:456
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:270
-#: org/libreplan/web/materials/MaterialsController.java:271
-#: org/libreplan/web/materials/MaterialsController.java:292
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:341
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1275
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1287
-#: org/libreplan/web/planner/order/SubcontractController.java:210
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:641
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:408
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:211
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:413
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:50
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:42
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:99
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:41
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:79
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:67
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:91
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:212
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:102
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:56
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:48
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:88
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:45
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:70
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:118
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:133
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:52
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:46
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:42
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:104
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:145
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:186
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:108
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:107
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:148
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:115
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:156
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:107
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:148
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:129
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:136
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:178
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:96
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:136
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:57
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:51
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:52
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:116
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:107
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:43
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:87
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:169
-msgid "Delete"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:105
-msgid "Currency"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:63
-msgid "Maximum/minimum of worked hours in finished applications"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/labels/labelTypes.zul:21
-msgid "LibrePlan: Labels"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:31
-msgid "Personal data"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:434
-msgid "Edit Virtual Workers Group: {0}"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:524
-msgid "No items found in 'OrderSyncInfo' to synchronize with JIRA issues"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:833
-#: org/libreplan/web/orders/OrderCRUDController.java:1049
-#: org/libreplan/web/resourceload/ResourceLoadController.java:414
-msgid "You don't have read access to this project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:52
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:52
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:47
-msgid "Criterion Requirement"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:516
-msgid "Criteria of this criterion type have been assigned to some resource."
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:364
-msgid " hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:115
-msgid "Go to edit worker window"
-msgstr ""
-
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:141
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:56
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:49
-msgid "Company"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:36
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:92
-msgid "Observations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:22
-msgid "LibrePlan: Page not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:251
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:55
-msgid "Delivery date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:193
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:96
-msgid "start date not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:48
-msgid "Value last progress reported"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:36
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:84
-msgid "Project Status Report"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:31
-msgid "Assigned criterion requirements"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:72
-msgid "Indent selected task"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:258
-#: org/libreplan/web/orders/OrderCRUDController.java:1442
-#: org/libreplan/web/orders/OrderElementTreeController.java:835
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:425
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:796
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:145
-#: org/libreplan/web/workreports/WorkReportQueryController.java:156
-#: org/libreplan/web/planner/order/OrderPlanningController.java:386
-#: org/libreplan/web/planner/company/CompanyPlanningController.java:314
-msgid "must be lower than end date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:231
-msgid "default maximum value of percentage progress type must be 100"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:101
-msgid "quality form type not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/Type.java:55
-msgid "From chosen date"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1296
-msgid "Add new progress measurement"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:51
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:53
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:55
-msgid "Probability %"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1161
-msgid "code is already used in another project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:58
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:29
-msgid "Subcontractor"
-msgstr ""
-
-#: org/libreplan/web/common/entrypoints/EntryPointsHandler.java:144
-msgid "{0} annotation required on {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:41
-#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:48
-msgid "Save changes"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:27
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:28
-msgid "New criterion"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:158
-msgid "Output format:"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:21
-msgid "LibrePlan: Work And Progress Per Task"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:81
-msgid ""
-"Invalid value. Precission value must be lower than the Default Max value."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:33
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:66
-msgid "Total work"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:29
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:170
-msgid "Quality form"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:213
-msgid "Budget in money"
-msgstr ""
-
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:90
-#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:130
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:174
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:308
-#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:168
-#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:125
-#: org/libreplan/web/reports/ProjectStatusReportController.java:188
-msgid "please, select a label"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:48
-msgid "Up to date"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1038
-#: org/libreplan/web/resourceload/ResourceLoadController.java:404
-msgid "The project has no scheduled elements"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:286
-msgid "Users"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:143
-msgid "No worklogs found for \"{0}\" key"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:167
-msgid "timesheet template name is already being used"
-msgstr ""
-
-#: org/libreplan/web/importers/ProjectImportController.java:89
-msgid ": Task import successfully!"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:81
-msgid "Progress Evolution"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:59
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:58
-msgid "Reviewed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:206
-msgid "Customer information"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CustomerCommunication.java:132
-msgid "project not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:118
-msgid "Planning Configuration"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:246
-msgid "Money spent"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:36
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:65
-msgid "More options"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:651
-msgid "Label type already assigned"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:20
-msgid "LibrePlan: Received From Subcontractors"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:58
-msgid "Company code"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:311
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:604
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:51
-msgid "Machines"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:498
-msgid "seconds planning warning not specified"
-msgstr ""
-
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:179
-msgid "{0} \"{1}\" can not be deleted because of it is being used"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:77
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:153
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:72
-msgid "Password confirmation"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1383
-msgid ""
-"Date is not valid, it must be later than the last progress reported to the "
-"customer"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:942
-msgid "Efforts"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:217
-msgid "No response or exception in response"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:60
-msgid "Move selected task down"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:445
-msgid "Criterion Type name is already being used"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:62
-msgid "By critical path hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:47
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:27
-msgid "Company ID"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:81
-msgid "length not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:201
-msgid "Only one sequence per entity can be active at the same time."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:148
-msgid "Association with profiles"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:167
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:126
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:967
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:981
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1440
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1467
-#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:320
-#: org/libreplan/web/orders/OrderCRUDController.java:1646
-#: org/libreplan/web/orders/OrderCRUDController.java:1670
-#: org/libreplan/web/orders/OrderElementTreeController.java:442
-#: org/libreplan/web/orders/TimSynchronizationController.java:142
-#: org/libreplan/web/common/ConfigurationController.java:925
-#: org/libreplan/web/common/ConfigurationController.java:1177
-#: org/libreplan/web/tree/TreeController.java:233
-#: org/libreplan/web/tree/TreeController.java:999
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:123
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:125
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:127
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:998
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1188
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1445
-#: org/libreplan/web/resources/worker/CriterionsController.java:212
-#: org/libreplan/web/resources/worker/CriterionsController.java:343
-#: org/libreplan/web/resources/worker/CriterionsController.java:351
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:319
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:325
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:236
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:348
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:357
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:135
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:144
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:148
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:205
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:305
-#: org/libreplan/web/templates/TemplatesTreeController.java:110
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:202
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:223
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:247
-#: org/libreplan/web/materials/UnitTypeController.java:128
-#: org/libreplan/web/materials/UnitTypeController.java:148
-#: org/libreplan/web/materials/MaterialsController.java:310
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:326
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:333
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:340
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:370
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:383
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:396
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:407
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:417
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:426
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:451
-#: org/libreplan/web/users/UserCRUDController.java:495
-#: org/libreplan/web/planner/reassign/ReassignController.java:143
-#: org/libreplan/web/montecarlo/MonteCarloController.java:159
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:192
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:196
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:361
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:479
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:44
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:55
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:61
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:45
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:53
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:89
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:94
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:43
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:38
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:52
-#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:49
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:35
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:41
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:61
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:31
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:37
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:45
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:56
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:34
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:43
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:50
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:43
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:58
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:46
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:74
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:129
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:48
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:58
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:64
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:53
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:44
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:54
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:39
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:94
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:96
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:161
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:50
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:96
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:43
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:54
-msgid "cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:645
-msgid "Create Timesheet"
-msgstr ""
-
-#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:464
-msgid "Split new assignment"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:30
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:28
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:61
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:44
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:68
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:28
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:68
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:141
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:161
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:34
-msgid "Actions"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:66
-msgid "Hour costs"
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersModel.java:144
-msgid "Please select a source scenario"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1693
-msgid "Regular project"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:617
-msgid "Please, select type of exception"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:112
-msgid "Finish hour"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:188
-msgid "The same resource is assigned twice inside an interval"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:263
-msgid "label type: the timesheet have not assigned this label type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/typeOfWorkHours.zul:23
-msgid "LibrePlan: Hours Types"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:264
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:109
-msgid "Company view"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:385
-msgid "Checked"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:118
-msgid "Timesheet"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:205
-msgid "timesheet not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:108
-msgid "Time"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/concurrent_modification.zul:34
-msgid "Please try it again."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:21
-msgid "LibrePlan: Expenses"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeController.java:1294
-msgid "Modified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:43
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:79
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:122
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:50
-msgid "Unselect"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:22
-msgid "Tim sync information"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:442
-msgid "Removed calendar \"{0}\""
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/CriterionBandboxFinder.java:44
-msgid "Criterion Name"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:140
-msgid "Resource / Criteria"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:54
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:133
-msgid "Add role"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:253
-msgid "Cost Variance"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:992
-#: org/libreplan/web/orders/OrderElementTreeController.java:849
-msgid ""
-"You can not remove the project \"{0}\" because this one has imputed expense "
-"sheets."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:31
-msgid "Planned start"
-msgstr ""
-
-#: org/libreplan/web/common/components/EffortDurationPicker.java:63
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:107
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:145
-msgid "Minutes"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:49
-msgid "Date last progress measurement"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:21
-msgid "LibrePlan: Estimated/Planned Hours Per Task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:43
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:67
-msgid "Permissions"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:132
-msgid "Projects since"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:250
-msgid "task cannot be empty if it is shared by lines"
-msgstr ""
-
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:295
-msgid "Virtual worker"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:60
-msgid "Work done from starting date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:22
-msgid "Scenarios List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:38
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:48
-msgid "Last expense"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:407
-msgid "Schedule from start to deadline"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:839
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:110
-msgid "Start hour"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:151
-msgid "Start Date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:296
-msgid "Host"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:73
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:57
-msgid "Pagination"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:169
-msgid "Alpha must be greater than 0"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportQueryController.java:262
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:78
-msgid "Indirect"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:93
-msgid "prefix not specified"
-msgstr ""
-
-#: org/libreplan/web/common/components/ResourceAllocationBehaviour.java:38
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:604
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:43
-msgid "Normal"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:34
-msgid "Base calendar type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_ordersTab.zul:33
-msgid "Save Project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:51
-msgid "Sorry for the inconvenience."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:29
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:172
-msgid "Predefined"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:287
-msgid "criterion name not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:517
-msgid "There is not any assigned progress to current task"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:352
-msgid "Project saved"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:99
-msgid "Export"
-msgstr ""
-
-#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:160
-#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:259
-msgid "All projects"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarModel.java:605
-msgid "Could not save the new calendar"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioCRUDController.java:238
-msgid "Scenario"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:488
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:39
-msgid "Estimated/Planned Hours Per Task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:123
-msgid "Create New Project"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:465
-msgid "last timesheet line sequence code not specified"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:247
-msgid "Estimation deviation on completed tasks"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:31
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:56
-msgid "Read"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:43
-msgid "Select report data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:121
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:41
-#: libreplan-webapp/src/main/webapp/planner/main.zul:57
-msgid "End"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:106
-msgid "default price not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:29
-msgid "Inherited labels"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:109
-msgid "Sum of direct expenses"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:383
-#: org/libreplan/importers/ExportTimesheetsToTim.java:291
-#: org/libreplan/importers/ImportRosterFromTim.java:239
-msgid "Worker \"{0}\" not found"
-msgstr ""
-
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:143
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:450
-msgid ""
-"Hours types are empty. Please, create some hours types before proceeding"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:98
-msgid "Select template"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1076
-msgid "Edit project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:107
-msgid "Disable Delete"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:43
-#: libreplan-webapp/src/main/webapp/common/error.zul:48
-msgid "Stacktrace"
-msgstr ""
-
-#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:164
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:207
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:337
-#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:202
-#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:159
-msgid "please, select a Criterion"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:162
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:28
-msgid "Finished"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/index.zul:22
-msgid "LibrePlan: Planning"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioModel.java:126
-msgid "You cannot remove the current scenario"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:719
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:755
-msgid "This progress type cannot be modified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:33
-msgid "Tim last sync"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:144
-msgid "Worker ID cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:39
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:45
-msgid "Apply"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1140
-msgid "Confirm editing user"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:244
-msgid "Work weeks list"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:27
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:29
-msgid "Job group"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:96
-msgid "connector name not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1329
-msgid "Assignment function will be changed. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:84
-msgid "{0} List"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:635
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1271
-msgid "Please, select an End Date for the Exception"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:111
-msgid "progress assignment not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:183
-msgid "Update exception"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:33
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:65
-msgid "Status"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:375
-msgid "Property strategy"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:21
-msgid "LibrePlan: Project Costs"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:265
-msgid "Changes saved"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:68
-msgid "Task Quality Form item name not specified"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:179
-msgid "Task deadline violations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:119
-msgid "Workable time"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:82
-msgid "Hours groups"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:101
-msgid "Assignment Type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:27
-msgid "Category data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:188
-msgid "Calendar exception days"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:21
-msgid "LibrePlan: Change password"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/GenericAllocationRow.java:55
-msgid "Generic"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:402
-msgid "Duplicate value AdvanceAssignment for order element of \"{0}\""
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:48
-msgid "Probability"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:487
-msgid ""
-"Deadline cannot be empty because there is a task with constraint \"as late "
-"as possible\""
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:47
-msgid "Last communication"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:245
-msgid "Delivery dates requested by customer. "
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:237
-#: org/libreplan/web/dashboard/DashboardController.java:264
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:35
-msgid "Number of tasks"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:275
-msgid "Please, select a calendar"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:155
-msgid "format sequence code invalid. It must not contain '_'"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:237
-msgid "maximum value must be greater than zero"
-msgstr ""
-
-#: org/libreplan/web/planner/milestone/AddMilestoneCommand.java:67
-msgid "Add Milestone"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:540
-msgid ""
-"Machine cannot be deleted. Machine is allocated to a project or contains "
-"imputed hours"
-msgstr ""
-
-#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:115
-msgid "A category must be selected"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/QualityFormBandboxFinder.java:51
-#: org/libreplan/web/common/components/finders/ResourceInExpenseSheetBandboxFinder.java:44
-#: org/libreplan/web/common/components/finders/CriterionBandboxFinder.java:44
-#: org/libreplan/web/common/components/finders/LabelBandboxFinder.java:52
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:48
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:42
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:47
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:153
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:28
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:47
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:113
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:27
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:44
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:68
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:83
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:46
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:79
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:135
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:176
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:97
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:138
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:105
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:146
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:97
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:138
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:85
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:126
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:168
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:86
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:126
-#: libreplan-webapp/src/main/webapp/templates/_advances.zul:36
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:25
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:49
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:62
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:35
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:51
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:154
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:33
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:56
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:91
-msgid "Type"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionsModel.java:216
-msgid "Resource type cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1342
-msgid ""
-"Value must be a multiple of the precision value of the progress type: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:163
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:35
-msgid "Overtime Effort"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:39
-msgid "Predecessor"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:44
-msgid "Select source"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:401
-msgid "fields should match with timesheet data if are shared by lines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:25
-msgid "Manual allocation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:546
-msgid "the same task is marked as finished by more than one timesheet line"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:439
-msgid "Confirm edit worker"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:100
-msgid "Day properties"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:598
-#: libreplan-business/src/main/java/org/libreplan/business/common/IntegrationEntity.java:48
-msgid "code not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:63
-msgid "Log"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:371
-#: org/libreplan/web/common/components/finders/BaseCalendarBandboxFinder.java:46
-#: org/libreplan/web/common/components/finders/TypeOfWorkHoursBandboxFinder.java:43
-#: org/libreplan/web/common/components/finders/QualityFormBandboxFinder.java:51
-#: org/libreplan/web/common/components/finders/ExternalCompanyBandboxFinder.java:51
-#: org/libreplan/web/common/components/finders/ScenarioBandboxFinder.java:46
-#: org/libreplan/web/common/components/finders/LabelBandboxFinder.java:52
-#: org/libreplan/web/tree/TreeComponent.java:94
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:437
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:935
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:52
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:26
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:42
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:77
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:40
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:36
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:28
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:110
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:80
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:27
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:437
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:66
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:76
-#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:27
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:32
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:52
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:27
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:26
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:28
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:40
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:41
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:25
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:39
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:27
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:45
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:32
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:53
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:108
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:35
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:56
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:34
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:51
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:92
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:136
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:177
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:96
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:98
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:139
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:106
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:147
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:98
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:139
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:117
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:87
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:127
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:169
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:87
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:127
-#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:51
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:26
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:62
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:48
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:36
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:42
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:83
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:96
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:27
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:60
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:27
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:34
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:50
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:43
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:134
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:156
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:81
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:32
-#: libreplan-webapp/src/main/webapp/planner/main.zul:49
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:31
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:50
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:46
-msgid "Name"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:987
-msgid "Worker and bound user deleted"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:576
-msgid "end"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:81
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:212
+msgid "Order element \"{0}\" not found"
+msgstr "Елемент проєкту \"{0}\" не знайдено"
+
+#: org/libreplan/web/orders/CriterionRequirementWrapper.java:87
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1088
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:252
+msgid "Inherited"
+msgstr "Успадкований"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:215
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:80
 msgid "quality form not specified"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionAdminController.java:200
-msgid "Criterion Type"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:323
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:105
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:127
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:507
-msgid "JIRA connector not found"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:355
-msgid "the project must have a deadline"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:125
-msgid "Label filter"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:21
-msgid "Templates List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:72
-msgid "Help"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:22
-msgid "Label Types List"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:256
-msgid "EAC"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:34
-msgid "Load 100%"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:284
-msgid "Stretch date must not be before task start date: "
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:422
-msgid "Select connector"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:149
-msgid "Assignments could not be completed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:39
-msgid "Number of applications"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:885
-msgid "New project version"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:31
-msgid "Transfer Projects Between Scenarios"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioCRUDController.java:243
-msgid "Scenarios"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:72
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:180
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:121
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:110
-msgid "task not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:33
-msgid "subelements"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderModel.java:713
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:100
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:59
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:43
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:29
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:67
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:36
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:62
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:31
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:77
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:37
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:49
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:83
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:54
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:87
-msgid "Description"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:50
-#: libreplan-webapp/src/main/webapp/common/error.zul:54
-msgid "Reload"
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:153
-msgid "No departments configured"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:221
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:80
-msgid "Infinitely Over Assignable"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:25
-msgid "Filter by"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:47
-msgid "Recommended allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:49
-#: libreplan-webapp/src/main/webapp/common/concurrent_modification.zul:36
-msgid "Continue"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:363
-msgid "Workable capacity for this period "
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:643
-msgid ""
-"IMPORTANT: Don't forget to communicate to subcontractor that his contract "
-"has been cancelled"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:152
-msgid "Criterion Requirements"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:81
-msgid "Total task budget"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:20
-msgid "Job Scheduling List"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:662
-msgid "Edit Timesheet"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:28
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:35
-msgid "Surname"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:31
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:34
-msgid "Assign quality form"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:44
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:40
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:146
-msgid "General data"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:292
-#: org/libreplan/web/templates/OrderTemplatesController.java:305
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:48
-msgid "Templates"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:66
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:52
-msgid "Subcontracting code"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1730
-msgid ""
-"It will only be possible to add an end date if all the exiting ones in the "
-"table have already been sent to the customer."
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:115
-msgid "The name is not valid, the name must not be null "
-msgstr ""
-
-#: org/libreplan/web/orders/TreeElementOperationsController.java:55
-msgid "Please select a task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:32
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:32
-msgid "Total price"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:313
-msgid "to {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:195
-msgid ""
-"Progress measurements must have a value lower than their following progress "
-"measurements."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:31
-msgid "Personal details"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:145
-msgid "cost assignment with end date before start date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:22
-msgid "Criterion Types List"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:251
-msgid "Actual Cost Work Performed"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesModel.java:133
-msgid "{0} (max: {1})"
-msgstr ""
-
-#: org/libreplan/web/planner/limiting/allocation/LimitingResourceAllocationModel.java:153
-#: org/libreplan/web/planner/allocation/FormBinder.java:659
-msgid ""
-"there are no resources for required criteria: {0}. So the generic allocation"
-" can't be added"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:242
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:261
-msgid "Prefix"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:324
-msgid "the cost category name has to be unique and it is already in use"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:812
-msgid "The max value must be greater than 0"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationModel.java:261
-msgid "Some sequences to be removed do not exist"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:49
-msgid "task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:67
-msgid "Constraint"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:44
-msgid "Worker assignments"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:92
-msgid "value must be greater or equal than 0"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:368
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:154
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:114
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:61
-msgid "Timesheets"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:988
-msgid "Worker deleted"
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:356
-msgid "Exception name should not be empty"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:978
-#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:149
-msgid "Not enough permissions to edit this project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:24
-msgid "Synchronization order elements with JIRA issues was successful"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:772
-msgid ""
-"Advance assignment cannot be removed as it has advance measures that have "
-"already been reported to the customer"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:105
-msgid "Hours Management"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:289
-msgid "Worker saved"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:110
-msgid "label names must be unique inside a label type"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:305
-msgid "Set Code as autogenerated to create a new project from templates"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:202
-msgid "cannot be empty or less than zero"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:63
-msgid "Next"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:184
-msgid "Timesheet templates"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:52
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:52
-msgid "Communication Type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:49
-msgid ""
-"If you reached this page from another page of LibrePlan please notify us in "
-"order to fix it as soon as possible."
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerModel.java:416
-msgid ""
-"Please, allow Multiple Active Criteria in this type in order to use selected"
-" Assignment Strategy"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:268
-msgid "default maximum value must be greater than precision value"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:100
-msgid "Must start after (days since project start)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:95
-msgid "New delivery date"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:410
-msgid "Schedule from deadline to start"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:1183
-msgid "Only digits allowed"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:529
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:539
-msgid "Repeated Hours Group code {0} in Project {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/worker.zul:22
-msgid "LibrePlan: Workers"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1573
-msgid "Not configurable"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:362
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:158
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:76
-msgid "Resources"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:297
-msgid "criterion satisfaction with end date before start"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:363
-msgid "Calculate Workable Days"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:945
-msgid ""
-"Spread progress cannot be changed if there is a consolidation in any "
-"progress assignment"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1696
-msgid "Please select a worker"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/concurrent_modification.zul:33
-msgid ""
-"Another user has modified the same data, so the operation cannot be safely "
-"completed."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:31
-msgid "MonteCarlo"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:62
-msgid "Sum of imputed hours in children tasks"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:402
-msgid "a disabled resource has enabled subresources"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeModel.java:433
-msgid "There is another timesheet template with the same code"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:51
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:127
-msgid "Association with roles"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1010
-msgid ""
-"This project is a subcontracted project. If you delete it, you won't be able"
-" to report progress anymore. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:409
-msgid "Backwards"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:32
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:32
-msgid "Customer Reference"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:116
-msgid "Both"
-msgstr ""
-
-#: org/libreplan/web/reports/ProjectStatusReportController.java:107
-msgid "You should filter the report by project, labels or criteria"
-msgstr ""
-
-#: org/libreplan/web/exceptionDays/CalendarExceptionTypeModel.java:102
-msgid "Cannot remove {0}, since it is being used by some exception day"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:35
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:46
-msgid "First expense"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:337
-msgid "Authentication"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:64
-msgid "Move selected task up"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:199
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:232
-msgid "Projects Planning"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:77
-msgid "New quality form item"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:666
-msgid "already exists an allocation for criteria {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:113
-msgid "Autocomplete login form"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportQueryController.java:373
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:115
-msgid "Tasks"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:440
-msgid "effort is not properly calculated based on clock"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:104
-msgid "unl"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementFilterEnum.java:36
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:838
-msgid "Label"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:106
-msgid "Prefix cannot contain whitespaces"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:35
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:99
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:81
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:38
-msgid "Assign"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:42
-msgid "Optimistic"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:121
-msgid "Apply tab changes"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:168
-msgid "Ok"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:462
-msgid "currency symbol not specified"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1045
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:293
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:122
-msgid "Worker"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:47
-msgid "Load due to current project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:36
-msgid "Add criterion requirement"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:93
-msgid "Number of iterations"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:156
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:72
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:35
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:166
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:270
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:29
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:30
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:82
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:124
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:165
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:86
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:86
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:127
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:94
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:135
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:86
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:127
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:107
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:75
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:107
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:157
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:75
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:115
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:47
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:59
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:97
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:66
-msgid "Add"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1025
-msgid "Removed {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:142
-msgid "Hours to allocate"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineConfigurationController.java:158
-msgid "Criterion previously selected"
-msgstr ""
-
-#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:252
-msgid ""
-"Are you sure of changing the resource type? You will lose the criteria with "
-"different resource type."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:104
-msgid "Total extra"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1379
-msgid ""
-"Date is not valid, it must be later than the last progress consolidation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1487
-msgid "a quality form cannot be assigned twice to the same task"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskGroup.java:110
-msgid "element associated to a task group have to be defined"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:118
-msgid "changing perspective"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:43
-msgid "Change password"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:68
-msgid "Queue-based resource allocation"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:125
+msgstr "форму якості не вказано"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:38
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:36
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:157
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:154
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:51
+#: libreplan-webapp/src/main/webapp/planner/main.zul:61
+msgid "Notes"
+msgstr "Нотатки"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:41
+msgid "Criteria (Hold CTRL for multiple selection)"
+msgstr "Критерії (утримуйте CTRL для множинного вибору)"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:123
 msgid "Progress percentage per progress type"
-msgstr ""
+msgstr "Відсоток прогресу за типом прогресу"
 
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:500
-msgid "Automatic"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:52
+msgid "Select queue"
+msgstr "Обрати чергу"
 
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:134
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:151
-msgid "months to"
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:370
+msgid "Calendar cannot be removed as it has other derived calendars from it"
 msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:39
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:39
-msgid "Total capability"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:57
-msgid "Filter by task status"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:78
-msgid "last synchronized date not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:723
-msgid "Calculated progress can not be modified"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:272
-msgid " (%d tasks)"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SubcontractController.java:147
-msgid ""
-"It will only be possible to add a Deliver Date if all the deliver date "
-"exiting in the table have a CommunicationDate not empty. "
-msgstr ""
-
-#: org/libreplan/web/resourceload/ResourceLoadModel.java:703
-msgid "Other projects"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:501
-msgid "Assign element to queue automatically"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:96
-msgid "Create & Assign"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1249
-msgid "Consolidated progress measurement cannot be removed"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:447
-msgid "label type: the timesheet has not assigned this label type"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:580
-msgid "project name is already being used"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:38
-msgid ""
-"Password cannot be managed for LDAP users because LDAP authentication is "
-"enabled."
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:372
-msgid "Calendar exception day not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:27
-msgid "External company"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:69
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:32
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:227
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:56
-msgid "Customer"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:120
-msgid "or names"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:196
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:137
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:158
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:166
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:66
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:159
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:139
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:190
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:148
-msgid "Format"
-msgstr ""
+"Календар не можна видалити, оскільки від нього є інші похідні календарі"
 
 #: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:192
 msgid "Quality form name is already being used"
-msgstr ""
+msgstr "Назва форми якості вже використовується"
 
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:72
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:122
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:158
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:84
-msgid "E-mail"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:56
-msgid "Access to the system"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:28
-msgid "Current state indicators"
-msgstr ""
-
-#: org/libreplan/web/importers/ProjectImportController.java:77
-msgid ": Calendar import successfully!"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:385
-msgid "Cannot connet to Tim server"
-msgstr ""
-
-#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:736
-msgid "End filtering date cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:328
-msgid "references"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:258
-msgid "ETC"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:558
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:539
 msgid "finished not specified"
-msgstr ""
+msgstr "стан завершення не вказано"
 
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:53
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:53
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:63
-msgid "Reference date"
-msgstr ""
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:61
+msgid "By critical path duration"
+msgstr "За тривалістю критичного шляху"
 
-#: org/libreplan/web/users/UserCRUDController.java:343
-msgid ""
-"User is bound to resource \"{0}\" and it will be unbound. Do you want to "
-"continue with user removal?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:83
-msgid "Resources Per Day"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1134
-msgid "criterion satisfaction codes must be unique inside a resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:268
-msgid "New end date for the customer"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:198
-msgid "Assigned Label Type cannot be repeated in a Timesheet Template."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConnectorProperty.java:51
-msgid "property key not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:51
-msgid "Edit selected task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:31
-msgid "Show labels"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:42
-msgid "Add From Template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:32
-msgid "Expense Sheets List"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1140
-msgid ""
-"resource cost category assignments codes must be unique inside a resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:21
-msgid "LibrePlan: Materials"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:104
-msgid "User disabled"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:223
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:161
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:183
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:191
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:91
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:184
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:164
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:213
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:173
-msgid "if the report is not opened automatically"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:292
-msgid "Unindent"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:51
-msgid ""
-"Allow multiple values of this type of criterion in the same period of time"
-msgstr ""
-
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:119
-msgid "please, select an item"
-msgstr ""
-
-#: org/libreplan/web/common/TemplateController.java:123
-#: org/libreplan/web/scenarios/ScenarioCRUDController.java:225
-msgid "error doing reassignment: {0}"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/UserDashboardController.java:64
-msgid "Personal timesheet \"{0}\" saved"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:44
-msgid "External load"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:36
-msgid "General user data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:43
-msgid "Entity sequences"
-msgstr ""
-
-#: org/libreplan/web/users/ProfileCRUDController.java:119
-msgid "Profile"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:351
-#: org/libreplan/web/materials/UnitTypeController.java:186
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:174
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:59
-msgid "Material Units"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractorCommunication.java:76
-msgid "subcontrated task data not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:46
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:56
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:53
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:90
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:60
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:76
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:50
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:55
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:45
-#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:45
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:62
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:60
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:163
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:81
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:44
-msgid "Generate code"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:717
-msgid "Changes applied"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:148
-msgid "company code not specified"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:52
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:37
-msgid "Task code"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractorCommunicationValue.java:73
-msgid "progress should be greater than 0% and less than 100%"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:109
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:190
-msgid "[generic all workers]"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:129
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:142
-msgid "Invalid Spread values. At least one value should be true"
-msgstr ""
-
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:112
-msgid "you do not have permissions to create new labels"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1177
-msgid "Create project"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:87
-msgid "price cost not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:111
-msgid "Down"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:74
-msgid "Page down"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesCommand.java:61
-msgid "Task Properties"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:120
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:36
-#: libreplan-webapp/src/main/webapp/planner/main.zul:53
-msgid "Start"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:67
-msgid "Labels list"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1003
-msgid ""
-"You can not remove the project \"{0}\" because it has time tracked at some "
-"of its tasks"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:84
-msgid "Total personal timesheet"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:56
-msgid "Precision"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:38
-msgid "Source scenario"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:66
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:102
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:55
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:55
-msgid "Project Code"
-msgstr ""
-
-#: org/libreplan/web/orders/CriterionRequirementWrapper.java:224
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:95
-msgid "Validate"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:427
-msgid ""
-"In the lines part, index labels and fields must be unique and consecutive"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:233
-msgid "expense line of the "
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:151
-msgid "Dependencies have priority"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:98
-msgid "Field"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:75
-msgid "Show dependencies"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:256
-msgid "Reassignation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:134
-msgid "timesheet template not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/timeout.zul:29
-msgid "Back to log in"
-msgstr ""
-
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:161
-msgid ""
-"Deleting this item will disable the report progress option. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:774
-#: org/libreplan/web/planner/company/CompanyPlanningModel.java:396
-msgid "date in the future"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:842
-msgid "Periods available depend on resources' calendar."
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:887
-msgid "It can not be deleted. At least one sequence is necessary."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:74
-msgid "Quality form items list"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsController.java:366
-msgid "Cannot insert material in general view. Please, select a category"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:966
-msgid ""
-"This worker cannot be deleted because it has assignments to projects or "
-"imputed hours"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1477
-msgid "Stretches with Interpolation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:23
-msgid "LibrePlan: Timesheets Templates"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:514
-msgid "Reports"
-msgstr ""
-
-#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:321
-msgid "Total dedication"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:673
-msgid "Code sequence is already in use and cannot be updated"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:242
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:218
-msgid "Invaldid End Date. New End Date must be after current End Date "
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersModel.java:153
-msgid "Source and destination scenarios should be different"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:870
-msgid ""
-"You cannot remove the task \"{0}\" because it is the only child of its "
-"parent and its parent has tracked time or imputed expenses"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:21
-msgid "LibrePlan: Task Scheduling Status In Project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:55
-msgid "START"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarModel.java:508
-msgid "This date can not include the whole previous work week"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:120
-msgid "Filter by categories or materials"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:22
-msgid "Users List"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/UserDashboardController.java:71
-msgid "Expense sheet \"{0}\" saved"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:335
-msgid "LDAP connection was successful"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:39
-msgid ""
-"The imported data are Gantt projects with their tasks, constraints, "
-"dependencies and milestones and there is also the option to upload "
-"calendars."
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeModel.java:330
-msgid "Already exists another criterion with the same name"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1240
-msgid "This progress type cannot be removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/access_forbidden.zul:38
-msgid "You do not have permissions to access to this page."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:108
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:197
-msgid "Day"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioCRUDController.java:178
-msgid "Connect"
-msgstr ""
-
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:165
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:190
-msgid "SPREAD"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:477
-msgid "Remove queue-based resource element"
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesModel.java:311
-#: org/libreplan/web/workreports/WorkReportTypeModel.java:408
-msgid "name cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:129
-msgid "Confirm cancel"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Machine.java:101
-msgid "machine name not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:172
-#: org/libreplan/web/orders/OrderCRUDController.java:1653
-msgid "project name already being used"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:373
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:944
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:62
-msgid "Timesheets Templates"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/AssignedMachineCriterionsModel.java:401
-#: org/libreplan/web/resources/worker/AssignedCriterionsModel.java:338
-msgid "The {0} is not valid. Other value exists from the same criterion type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:22
-msgid "Workers List"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:335
-msgid ""
-"The original workable days value {0} cannot be modified as it has "
-"consolidations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:22
-msgid "JIRA sync information"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:482
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:39
-msgid "Work And Progress Per Task"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:182
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:182
-msgid "Criterion already assigned"
-msgstr ""
-
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:515
-msgid "Progress cannot be consolidated."
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/EditTaskController.java:359
-msgid ""
-"The task has got progress consolidations. To change resource allocation type"
-" all consolidations must be removed before"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:275
-msgid "Expiry date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:26
-msgid "Imputed hours calculation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:72
-msgid "quality form item name not specified or empty"
-msgstr ""
-
-#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:248
-#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:294
-msgid "Problems connecting with subcontractor web service"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:71
-msgid "New password"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:95
-msgid "Cron expression format"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:34
-msgid ""
-"Synchronization of timesheets is not completed for the following reasons:"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:714
-msgid "Progress that are reported by quality forms can not be modified"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:345
-msgid "Quality form cannot be removed as it is spreading progress"
-msgstr ""
-
-#: org/libreplan/web/resourceload/ResourceLoadController.java:667
-msgid "Resources or criteria"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:216
-msgid "The quality form item positions must be unique and consecutive."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:158
-#: org/libreplan/web/workreports/WorkReportTypeModel.java:427
-msgid ""
-"Value is not valid.\n"
-" Code cannot contain chars like '_'."
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:236
-msgid ""
-"Days Interval (Calculated as task completion end date minus estimated end "
-"date)"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:98
-msgid "Expense sheet \"{0}\" deleted"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:81
-msgid "Application settings"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:29
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:30
 #: libreplan-webapp/src/main/webapp/orders/_splitMaterialAssignmentDlg.zul:38
 #: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:29
 msgid "Units"
-msgstr ""
+msgstr "Одиниці"
 
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:508
-#: org/libreplan/web/planner/company/CompanyPlanningModel.java:452
-msgid "Select date"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:156
+msgid "Generate code for"
+msgstr "Згенерувати код для"
 
-#: org/libreplan/web/workreports/WorkReportQueryController.java:374
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:68
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:197
-msgid "Total hours"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:20
+msgid "LibrePlan: Project Status Report"
+msgstr "LibrePlan: Звіт про статус проєкту"
 
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1053
-msgid "Some criterion satisfactions overlap in time"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:185
+msgid "userId not specified"
+msgstr "userId не вказано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:122
-msgid "worker's first name not specified"
+#: org/libreplan/web/users/UserCRUDController.java:109
+msgid "Default user \"admin\" cannot be removed as it is mandatory"
 msgstr ""
+"Типового користувача \"admin\" не можна видалити, оскільки він є обов'язковим"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:443
-msgid "Test connection"
-msgstr ""
+#: org/libreplan/web/orders/JiraSynchronizationController.java:195
+msgid "No JIRA issues to import"
+msgstr "Немає проблем JIRA для імпорту"
 
-#: org/libreplan/web/resourceload/ResourceLoadController.java:552
-msgid "From"
-msgstr ""
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:56
+msgid "Expected"
+msgstr "Очікуване"
 
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:141
-msgid "Earlier starting date"
-msgstr ""
+#: org/libreplan/web/planner/allocation/AllocationRow.java:628
+msgid "{0} cannot be fulfilled"
+msgstr "{0} не може бути виконано"
 
-#: libreplan-webapp/src/main/webapp/planner/reassign.zul:34
-msgid "Reassigning type"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:997
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:563
+msgid "yes"
+msgstr "так"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:23
-msgid "LibrePlan: Main Settings"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:23
+msgid "LibrePlan: Timesheets Templates"
+msgstr "LibrePlan: Шаблони табелів"
 
-#: org/libreplan/web/common/CustomMenuController.java:419
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:69
-msgid "Job Scheduling"
-msgstr ""
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:253
+msgid "Estimate To Complete"
+msgstr "Оцінка до завершення"
 
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:784
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:793
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:225
+msgid "Expenses budget"
+msgstr "Бюджет витрат"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:72
+msgid "Main menu"
+msgstr "Головне меню"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:38
+msgid "Total estimated hours"
+msgstr "Загальна кількість оцінених годин"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:22
+msgid "LibrePlan: Advanced allocation"
+msgstr "LibrePlan: Розширений розподіл"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:74
+msgid "Connector"
+msgstr "Конектор"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:498
 msgid ""
-"There are unsaved changes in the current personal timesheet, please save "
-"before moving"
+"Starting date cannot be empty because there is a task with constraint \"as "
+"soon as possible\""
 msgstr ""
+"Дата початку не може бути порожньою, оскільки є завдання з обмеженням "
+"\"якомога раніше\""
 
-#: org/libreplan/web/importers/ProjectImportController.java:105
-msgid "Select one of the options."
-msgstr ""
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:89
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:140
+msgid "Select"
+msgstr "Обрати"
 
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:76
-msgid "Delete selected task"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:147
+msgid "Enable/Disable warning about new LibrePlan versions available"
+msgstr "Увімкнути/вимкнути попередження про наявність нових версій LibrePlan"
 
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:108
-msgid "Task of project"
-msgstr ""
+#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:116
+#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:122
+#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:147
+msgid "Please, select a project"
+msgstr "Будь ласка, оберіть проєкт"
 
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:360
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:698
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:618
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:184
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:92
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:33
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:92
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:95
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:50
-msgid "Total"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:33
+msgid "Communications From Subcontractors"
+msgstr "Комунікації від субпідрядників"
 
-#: org/libreplan/web/planner/advances/AdvanceAssignmentPlanningCommand.java:69
-msgid "Progress assignment"
-msgstr ""
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:616
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:652
+msgid "Assigned resources for this task will be deleted. Are you sure?"
+msgstr "Призначені ресурси для цього завдання будуть видалені. Ви впевнені?"
 
-#: org/libreplan/web/materials/UnitTypeController.java:133
-msgid ""
-"The meausure name is not valid. There is another unit type with the same "
-"measure name"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:853
+msgid "Queue-based resource"
+msgstr "Ресурс на основі черги"
 
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1325
-msgid ""
-"Progress measurement cannot be canged to {0}, because it is consolidated"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1692
-msgid "Subcontracted by client"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:132
-msgid "Go to personal timesheet"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:318
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:324
-msgid "Day is not valid"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:185
-msgid "No work reportlines are found for order: \"{0}\""
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:54
-msgid "Select queue"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:171
-msgid "default password was not changed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:32
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:58
-msgid "Color"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:47
-msgid "Add new worker assignment"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:66
-msgid "Filter by workers"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:35
-msgid "Expand taskgroups"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:22
-msgid "LibrePlan: Send To Subcontractors"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/ManualAllocationController.java:492
-msgid "END"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:337
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:237
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:56
-msgid "Progress Types"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:56
-msgid "Work description"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:139
-msgid "Report data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:30
-msgid "Next fire time"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1011
-#: org/libreplan/web/common/BaseCRUDController.java:313
-#: org/libreplan/web/templates/OrderTemplatesController.java:378
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:162
-#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:92
-msgid "Confirm"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1120
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1116
 msgid ""
 "there exist criterion satisfactions referring to criterion types not "
 "applicable to this resource"
 msgstr ""
+"існують задоволення критеріїв, що посилаються на типи критеріїв, непридатні "
+"для цього ресурсу"
 
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:361
-msgid "Reassign"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:29
+msgid "Reception date"
+msgstr "Дата отримання"
 
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:44
-msgid "Pessimistic"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:267
+msgid "Work weeks list"
+msgstr "Список робочих тижнів"
 
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:52
-msgid "Apply filtering to resources satisfying required criteria"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:170
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:199
+msgid "months to"
+msgstr "місяців до"
 
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:210
-msgid "Quality form item name must be unique"
-msgstr ""
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:328
+msgid "Length percentage should be between 0 and 100"
+msgstr "Відсоток довжини повинен бути між 0 і 100"
 
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:122
-msgid "cost category not specified"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:462
+msgid "(If it is empty, a node strategy is used)"
+msgstr "(Якщо порожньо, використовується стратегія вузла)"
 
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1216
-msgid "calendars with zero hours are not allowed"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:52
+msgid "Default max value"
+msgstr "Типове максимальне значення"
 
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:42
-msgid "WBS (tasks)"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:123
+msgid "Expense date"
+msgstr "Дата витрати"
 
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:573
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1020
-msgid "yes"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:173
+msgid "For more details on cron expression click"
+msgstr "Для отримання додаткової інформації про cron-вираз натисніть"
 
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:274
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:959
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1219
-msgid "Please, select an item"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1124
+msgid "a label can not be assigned twice in the same branch"
+msgstr "мітку не можна призначити двічі в одній гілці"
 
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:71
-msgid "Exportation options"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:50
+msgid "Worker assignments"
+msgstr "Призначення працівників"
 
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:330
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:709
 msgid ""
-"Error saving the project\n"
-"{0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/VirtualWorker.java:97
-msgid "Virtual worker group name must be unique"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:254
-msgid "SV"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:774
-msgid "The length must be greater than 0 and not empty"
-msgstr ""
-
-#: org/libreplan/web/importers/ProjectImportController.java:96
-msgid ": Import successfully!"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:29
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:66
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:28
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:61
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:58
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:27
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:28
-msgid "Enabled"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1244
-msgid "Calculated progress measurements cannot be removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:189
-msgid "Exceptions list"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:599
-msgid "Machine"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:71
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:59
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:118
-msgid "en"
-msgstr "uk"
-
-#: libreplan-webapp/src/main/webapp/common/access_forbidden.zul:40
-msgid ""
-"Please try to contact with any administrator in order to review your "
-"permissions in LibrePlan."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/costcategories/costCategory.zul:23
-msgid "LibrePlan: Cost Categories"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:120
-msgid "Unbound resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:20
-msgid "LibrePlan: Received From Customers"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:47
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:106
-msgid "New timesheet"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:41
-msgid "Tim product code"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1134
-msgid "Cannot be higher than finish hour"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:839
-msgid "In the available periods {0} only {1} hours are available."
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineConfigurationController.java:129
-msgid "No worker selected"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:257
-msgid "Variance At Completion"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:375
-msgid "Calculate Number of Hours"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/ResourceCalendar.java:73
-msgid "Capacity must be a positive integer number"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:42
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:43
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:65
-msgid "Template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:279
-msgid "Activation"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:255
-msgid "BAC"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:128
-msgid "Add New Complementary Field"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:70
-msgid "Assignation type"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1047
-msgid "Virtual Workers Group"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:115
-msgid "No workers found"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1051
-msgid "Task {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:567
-msgid ""
-"there is a timesheet line in another work report marking as finished the "
-"same task"
-msgstr ""
-
-#: org/libreplan/web/common/components/NewAllocationSelector.java:55
-msgid "generic workers allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:150
-msgid ""
-"Profiles of LDAP users cannot be managed because LDAP is enabled and LDAP "
-"roles are being used."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:248
-msgid ""
-"The quality item positions must be correct in function to the percentage."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:361
-msgid "deadline must be after start date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:38
-msgid "The formats supported for import are MPP and PLANNER files."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:221
-msgid "progress type marked as quality form but is updatable"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:45
-msgid "Personal Data"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:280
-msgid "cannot be checked until the previous item is checked before"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:161
-msgid "ID already used. It has to be be unique"
-msgstr ""
-
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:879
-#: org/libreplan/web/planner/company/CompanyPlanningModel.java:542
-msgid "h"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:26
-msgid "Assigned locations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:124
-msgid "0 or 7 is Sunday, or use names"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:23
-msgid "Criteria list"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:27
-msgid "Select criteria set or specific resources for allocation"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:472
-#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:103
-#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:150
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:391
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:970
-#: org/libreplan/web/users/ProfileCRUDController.java:155
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:575
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:613
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:644
-#: org/libreplan/web/planner/taskedition/AdvancedAllocationTaskController.java:73
-msgid "Warning"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:357
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:344
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:53
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:49
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:60
-msgid "Quality Forms"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:158
-msgid "Default Label"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:144
-msgid "Hours group"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:80
-msgid "Price per hour"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:192
-msgid "Create new user"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:278
-#: org/libreplan/web/planner/tabs/ResourcesLoadTabCreator.java:102
-#: org/libreplan/web/planner/tabs/ResourcesLoadTabCreator.java:111
-#: org/libreplan/web/planner/tabs/ResourcesLoadTabCreator.java:138
-#: org/libreplan/web/planner/tabs/ResourcesLoadTabCreator.java:160
-msgid "Resources Load"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:265
-msgid "Timesheet saved"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:680
-msgid "task code is repeated inside the project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:38
-msgid "Total estimated hours"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/EditTaskController.java:152
-msgid "Edit task: {0}"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/AssignedMachineCriterionsModel.java:398
-#: org/libreplan/web/resources/worker/AssignedCriterionsModel.java:333
-msgid ""
-"The {0} can not be assigned to this resource. Its interval overlaps with "
-"other criterion"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:44
-msgid "Cancel changes and back to scheduling"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:127
-msgid "Go to edit user window"
-msgstr ""
-
-#: org/libreplan/web/planner/milestone/DeleteMilestoneCommand.java:59
-msgid "Delete Milestone"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:270
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:48
-msgid "Projects"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:374
-msgid "Group strategy"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:124
-msgid "{0} 2nd fortnight"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SubcontractController.java:287
-#: org/libreplan/web/planner/order/SubcontractController.java:290
-msgid "Update task end"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:300
-msgid "criterion type not specified"
-msgstr ""
-
-#: org/libreplan/web/labels/LabelTypeCRUDController.java:266
-#: org/libreplan/web/labels/LabelTypeModel.java:154
-#: org/libreplan/web/labels/LabelTypeModel.java:182
-#: org/libreplan/web/scenarios/ScenarioModel.java:221
-#: org/libreplan/web/calendars/BaseCalendarModel.java:602
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:206
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:227
-#: org/libreplan/web/materials/MaterialsModel.java:175
-msgid "{0} already exists"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:190
-msgid "Calculated budget"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:63
-msgid "Date Start"
-msgstr ""
-
-#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementModel.java:206
-msgid "New hours group "
-msgstr ""
-
-#: org/libreplan/web/planner/adaptplanning/AdaptPlanningCommand.java:70
-msgid "Adapting planning according to timesheets"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:182
-msgid "There must be at least 2 stretches for doing interpolation"
-msgstr ""
-
-#: org/libreplan/importers/ImportRosterFromTim.java:165
-msgid "Import roster for department {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/Profile.java:68
-msgid "profile name not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:329
-msgid "Code already included in Hours Group codes"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:101
-msgid "last value not specified"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionsModel.java:179
-msgid "{0} not found type for criterion "
-msgstr ""
+"Subcontractor values are read only because they were reported by the "
+"subcontractor company"
+msgstr ""
+"Значення субпідрядника доступні лише для читання, оскільки вони були надані "
+"компанією-субпідрядником"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:288
+msgid "criterion satisfaction with end date before start"
+msgstr "задоволення критерію з датою завершення раніше за початок"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:48
+msgid "Value last progress reported"
+msgstr "Значення останнього звіту про прогрес"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/UnitType.java:85
 msgid "the measure has to be unique"
-msgstr ""
+msgstr "одиниця виміру повинна бути унікальною"
 
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:98
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:110
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:33
-msgid "Bound resource"
-msgstr ""
+#: org/libreplan/web/planner/TaskElementAdapter.java:1291
+#: org/libreplan/web/planner/TaskElementAdapter.java:1311
+msgid "{0} not supported yet"
+msgstr "{0} ще не підтримується"
 
-#: org/libreplan/web/common/ConfigurationController.java:1169
-msgid "Only {0} allowed"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:45
+msgid "Customer reference code"
+msgstr "Референсний код замовника"
 
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:57
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:43
-msgid "Current"
-msgstr ""
+#: org/libreplan/web/orders/OrdersTreeComponent.java:76
+msgid "Total task budget"
+msgstr "Загальний бюджет завдання"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:411
-msgid "LDAP Roles (separated by ;)"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:23
+msgid "LibrePlan: Transfer Projects Between Scenarios"
+msgstr "LibrePlan: Перенесення проєктів між сценаріями"
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:129
+#: org/libreplan/web/workreports/WorkReportTypeModel.java:423
+msgid "Code cannot be empty"
+msgstr "Код не може бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:116
+msgid "Time"
+msgstr "Час"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:47
+msgid "Cancel and return"
+msgstr "Скасувати та повернутися"
+
+#: org/libreplan/web/tree/TreeComponent.java:160
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:47
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:324
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:37
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:182
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:296
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:72
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:32
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:31
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:110
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:77
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:117
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:85
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:126
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:96
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:140
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:80
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:116
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:168
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:87
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:137
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:180
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:85
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:87
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:130
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:102
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:60
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:67
+msgid "Add"
+msgstr "Додати"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:133
+msgid "Timesheet"
+msgstr "Табель"
+
+#: org/libreplan/web/dashboard/DashboardController.java:185
+msgid "Violated deadline"
+msgstr "Порушений кінцевий термін"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:223
+msgid "Subcategory names must be unique."
+msgstr "Назви підкатегорій повинні бути унікальними."
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:53
+msgid "New entry"
+msgstr "Новий запис"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:28
+msgid "User data"
+msgstr "Дані користувача"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:311
+msgid "Indent"
+msgstr "Відступ"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:890
+msgid "Done"
+msgstr "Готово"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:76
+msgid "Group name"
+msgstr "Назва групи"
+
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:31
+msgid "Quality forms"
+msgstr "Форми якості"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:182
+msgid "Resources load filtering"
+msgstr "Фільтрація завантаження ресурсів"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:143
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:65
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:152
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:157
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:173
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:200
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:212
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:145
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:164
+msgid "Format"
+msgstr "Формат"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:146
+msgid "default calendar not specified"
+msgstr "типовий календар не вказано"
+
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:99
+msgid "Deadline (days since project start)"
+msgstr "Кінцевий термін (днів від початку проєкту)"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:367
+msgid "Checked"
+msgstr "Позначено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:477
 msgid ""
-"Help the project developers to collect information about which LibrePlan "
-"version you are using"
-msgstr ""
+"In personal timesheets, all timesheet lines should be in the same period"
+msgstr "В особистих табелях усі рядки табелю повинні бути в одному періоді"
 
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:190
-msgid "Not bound"
-msgstr ""
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:363
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:51
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:81
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:74
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:86
+#: libreplan-webapp/src/main/webapp/planner/order.zul:105
+msgid "Percentage"
+msgstr "Відсоток"
 
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:101
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:45
-msgid "Bound user"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:22
+msgid "Criterion Types List"
+msgstr "Список типів критеріїв"
 
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:32
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:57
-msgid "Write"
-msgstr ""
+#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:135
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:462
+msgid "Confirm deleting this hour cost. Are you sure?"
+msgstr "Підтвердити видалення цієї вартості годин. Ви впевнені?"
 
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:112
-msgid "total not specified"
-msgstr ""
-
-#: org/libreplan/web/common/entrypoints/RedirectorSynthetiser.java:125
-msgid "Could not load any resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:50
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:45
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:43
-msgid "Dates"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:492
-msgid ""
-"Value is not valid.\n"
-" Code cannot contain chars like '_' \n"
-" and should not be empty"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:453
-msgid "currency code not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:137
-msgid "Choosing Template"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/ResourceInExpenseSheetBandboxFinder.java:44
-msgid "Resource name (Resource code)"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:463
-msgid "Starting date cannot be empty in forward mode"
-msgstr ""
-
-#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:126
-#: org/libreplan/web/orders/JiraSynchronizationController.java:313
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:1082
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:81
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:116
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:74
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:90
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:132
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:104
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:453
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:90
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:165
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:70
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:139
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:106
-#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:49
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:58
-#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:46
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:94
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:49
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:103
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:98
-#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:43
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:129
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:137
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:135
-#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:39
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:238
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:188
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:50
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:91
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:83
-#: libreplan-webapp/src/main/webapp/planner/reassign.zul:50
-#: libreplan-webapp/src/main/webapp/planner/order.zul:131
-#: libreplan-webapp/src/main/webapp/planner/order.zul:166
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:42
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:184
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:97
-msgid "Cancel"
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersModel.java:170
-msgid "Project version is the same in source and destination scenarios"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:117
-msgid "Expense date"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionAdminController.java:114
-msgid "Tree {0} sucessfully flattened"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:39
-#: libreplan-webapp/src/main/webapp/common/error.zul:44
-msgid "Status code"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementController.java:122
-msgid "Edit task {0}"
-msgstr ""
-
-#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:403
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:628
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:351
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:331
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1320
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:121
-msgid "Error"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:220
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:158
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:180
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:188
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:88
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:181
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:161
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:210
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:169
-msgid "Click on this"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:595
-msgid "Exception: {0} (Inh)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:26
-msgid "Calendar data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:89
-msgid "Select language"
-msgstr ""
-
-#: org/libreplan/web/subcontract/ReportAdvancesModel.java:224
-msgid "Problems connecting with client web service"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:246
-msgid "progress type name is already in use"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:46
-msgid "Labels without inheritance"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/access_forbidden.zul:43
-msgid "Click the following link to return to home page: "
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1371
-msgid "See scheduling"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:43
-msgid "Select the elements to import into LibrePlan"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:35
-#: libreplan-webapp/src/main/webapp/common/error.zul:40
-msgid "Exception type"
-msgstr ""
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:340
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:697
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:608
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:207
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:226
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:100
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:34
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:53
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:109
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:117
+msgid "Total"
+msgstr "Всього"
 
 #: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:56
 msgid ""
 "LDAP users cannot change their password if LDAP authentication is enabled. "
 "Talk to one of the administrators"
 msgstr ""
-
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:60
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:140
-msgid "Role name"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:60
-msgid "Required materials"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:245
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:263
-msgid "Number of digits"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:44
-msgid "Lines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:69
-msgid "Extended view"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:61
-msgid "unit price not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:208
-msgid "Perspectives"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/timeout.zul:27
-msgid "Your session has expired because of inactivity. Please log in again."
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:281
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:75
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:63
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:116
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:167
-msgid "User"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:66
-msgid "Project closing previsions"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:838
-msgid ""
-"Invalid format prefix. Format prefix cannot be empty, contain '_' or contain"
-" whitespaces."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:155
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:169
-msgid "The current value must be less than the max value."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:43
-msgid "Filter by month"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:419
-msgid "Calendar cannot be removed as it has other derived calendars from it"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:470
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:39
-msgid "Total Worked Hours By Resource In A Month"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:69
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:219
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:86
-msgid "cannot be negative or empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:113
-msgid "Select gap"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:149
-msgid "Period"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerModel.java:244
-msgid "Worker must be not-null"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:35
-msgid "Communications To Subcontractors"
-msgstr ""
-
-#: org/libreplan/web/users/OrderAuthorizationController.java:120
-msgid ""
-"Could not add those authorizations to profile {0} because they were already "
-"present."
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:218
-msgid "Resource: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:265
-msgid "Last value"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:40
-#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:47
-msgid "Edit Calendar"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1411
-msgid "End date can only be deleted in the last activation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:191
-msgid "userId not specified"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeController.java:1003
-msgid "cannot be negative"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:40
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:27
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:54
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:50
-msgid "from"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:388
-msgid "Calculate Resources per Day"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:54
-msgid "Job class name"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:390
-#: org/libreplan/web/common/JobSchedulerController.java:395
-msgid "Job scheduling"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:39
-msgid "Estimated hours"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/UserBandboxFinder.java:47
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:53
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:144
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:47
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:27
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:36
-msgid "Username"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:97
-msgid "Go!"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportQueryController.java:290
-msgid "Task not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:252
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:274
-msgid "Valid from"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:100
-msgid "Total extra per day"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:137
-msgid "Default user \"admin\" cannot be removed as it is mandatory"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:82
-msgid "Resources usage"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:231
-msgid "Completed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:127
-msgid "Year (optional)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:65
-msgid "Current password"
-msgstr ""
-
-#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:211
-msgid "Cannot remove the predefined calendar exception day \"{0}\""
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:317
-msgid "UserDn"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:74
-msgid "type"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorization.java:43
-msgid "an authorization type must be set"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:66
-msgid "Own exception"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:431
-#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:146
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:70
-msgid "Companies"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:29
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:34
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:55
-msgid "Label type"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:254
-msgid "Schedule Variance"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceAssignment.java:75
-msgid "progress type not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:87
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:78
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:29
-msgid "Disabled"
-msgstr ""
-
-#: org/libreplan/web/planner/calendar/CalendarAllocationCommand.java:58
-#: libreplan-webapp/src/main/webapp/planner/order.zul:143
-msgid "Calendar allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:21
-msgid "LibrePlan: Total Worked Hours By Resource In A Month"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionAdminController.java:257
-msgid ""
-"This criterion type cannot be deleted because it is assigned to projects or "
-"resources"
-msgstr ""
-
-#: org/libreplan/web/importers/ProjectImportController.java:110
-msgid "The only current suported formats are mpp and planner."
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:232
-msgid "Progress Type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:69
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:66
-msgid "Identification"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderElementTreeController.java:859
-msgid ""
-"You cannot remove the task \"{0}\" because it has work reported on it or any"
-" of its children"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:65
-msgid "Zoom"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:663
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1049
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:31
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:66
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:47
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:42
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:53
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:138
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderTemplate.java:64
-msgid "Project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:84
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:112
-msgid "Select"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:130
-msgid ""
-"Check this option if you would like to send feedback to LibrePlan developers"
-" about program usage"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:22
-msgid "LibrePlan: Settings"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:345
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:54
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:55
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:178
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:22
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:52
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:48
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:35
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:58
-msgid "Materials"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:26
-msgid "Filter quality forms by"
-msgstr ""
-
-#: org/libreplan/web/orders/DynamicDatebox.java:149
-msgid "Date format is wrong. Please, use the following format: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:88
-msgid "Total other"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:142
-msgid "Change the password"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/access_forbidden.zul:20
-msgid "LibrePlan: Access Forbidden"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:50
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:52
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:54
-msgid "Estimated days"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:22
-msgid "Virtual Workers Groups List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:33
-msgid "Communications From Subcontractors"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/requirements/entities/IndirectCriterionRequirement.java:77
-msgid "parent not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:106
-msgid "Has bound resource"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:407
-msgid "Forward"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:33
-msgid "Total Budget"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:443
-msgid "Edit queue-based resource element"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:93
-msgid "job class name not specified"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:60
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:36
-msgid "Spreading progress"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:164
-msgid "OK"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:970
-msgid "Confirm deleting this worker. Are you sure?"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/Task.java:189
-msgid "element associated to a task must be not empty"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:71
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionValue.java:71
-msgid "field name not specified or empty"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:288
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:525
-msgid "must be after the previous date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:34
-msgid "JIRA label"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:47
-msgid "Cancel and return"
-msgstr ""
-
-#: org/libreplan/web/users/OrderAuthorizationController.java:92
-msgid "No authorizations were added because you did not select any."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/users.zul:23
-msgid "LibrePlan: User Accounts"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:30
-msgid "Quality forms"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:494
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:39
-msgid "Project Costs"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:88
-msgid "Overtime ratio"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsController.java:375
-msgid "Materials saved"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:104
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:866
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:34
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:205
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:257
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:278
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:86
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:51
-msgid "Op."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:215
-msgid "Add Criterion"
-msgstr ""
-
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:259
-msgid "percentage must be unique"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:155
-msgid "expense sheet not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:71
-msgid "Interacts with applications"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:22
-msgid "LibrePlan: Advanced allocation"
-msgstr ""
-
-#: org/libreplan/importers/CalendarImporterMPXJ.java:365
-msgid "Calendar name already in use"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1061
-msgid "Hours Group at {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:178
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:259
-msgid "%"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:632
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1179
-#: org/libreplan/web/users/UserCRUDController.java:523
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:58
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:48
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:50
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:34
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:56
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:35
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:55
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:52
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:49
-#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:32
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:58
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:33
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:56
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:40
-msgid "Create"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1571
-msgid "must be later than start date"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:397
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:46
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:46
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:159
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:67
-msgid "Cost"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:100
-msgid ""
-"Load percentage of resources participating in the project while they are "
-"assigned"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:247
-msgid "add"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:256
-msgid "Summary"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:295
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:309
-msgid "Not indentable"
-msgstr ""
-
-#: org/libreplan/web/montecarlo/MonteCarloController.java:192
-msgid "Percentages should sum 100"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:130
-msgid "Order should not be empty"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/UnitType.java:76
-msgid "measure not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1723
-#: org/libreplan/web/planner/order/SubcontractController.java:140
-msgid "You must select a valid date. "
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:666
-msgid "Regular"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:90
-msgid "Must start after"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/Type.java:43
-msgid "From today"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:183
-#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:50
-msgid "Project Details"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/ResourceAllocationFilterEnum.java:30
-#: org/libreplan/web/common/components/finders/ResourceBandboxFinder.java:46
-#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:32
-#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
-#: org/libreplan/web/common/components/finders/ResourceFilterEnumByResourceAndCriterion.java:31
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:799
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:33
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:86
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:69
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:44
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:100
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:81
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:185
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:95
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:151
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:171
-msgid "Resource"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:34
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:72
-msgid "Standard Effort"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:21
-msgid "LibrePlan: Import Project"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:730
-msgid "Create Virtual Workers Group"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:145
-msgid ""
-"Please use some of the compatible browsers: Chrome, Firefox, Safari or "
-"Epiphany."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:23
-msgid "LibrePlan: Transfer Projects Between Scenarios"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:306
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:50
-msgid "Workers"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:351
-msgid ""
-"Last stretch should have one hundred percent length and one hundred percent "
-"of work percentage"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:35
-msgid "Planned end"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:613
-#: libreplan-webapp/src/main/webapp/myaccount/userDashboard.zul:35
-msgid "My dashboard"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:50
-msgid "Work amount"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1690
-msgid "Please set a date"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:332
-msgid "Hours type should not be empty to synchronine timesheets"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:1339
-#: org/libreplan/web/orders/OrderElementTreeController.java:590
-#: org/libreplan/web/common/Util.java:656
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:366
-#: org/libreplan/web/templates/TemplatesTreeController.java:79
-#: org/libreplan/web/limitingresources/QueueComponent.java:478
-#: org/libreplan/web/subcontract/SubcontractorCommunicationCRUDController.java:241
-#: org/libreplan/web/subcontract/CustomerCommunicationCRUDController.java:196
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:45
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:37
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:36
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:49
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:43
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:40
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:28
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:33
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:47
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:42
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:37
-#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:25
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:46
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:47
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:26
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:37
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:134
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:81
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:26
-msgid "Edit"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:116
-msgid "unit name not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:79
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:114
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:72
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:67
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:136
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:104
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:92
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:100
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:186
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:96
-#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:42
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:127
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:134
-#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:39
-#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:38
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:234
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:186
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:182
-msgid "Save & Continue"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:159
-msgid "Order element \"{0}\" not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:169
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:198
-msgid "Exception Type"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:611
-msgid "My account"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:451
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:74
-msgid "Received From Customers"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:281
-msgid "Create activation period"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:162
-msgid "Export product code {0}, project {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:78
-msgid "Imputed expenses"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:212
-msgid "Task: {0}"
-msgstr ""
-
-#: org/libreplan/web/subcontract/SubcontractedTasksController.java:216
-msgid "Subcontracted task sent successfully"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsModel.java:275
-msgid "both {0} of category {1} and {2} of category {3} have the same code"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:196
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:748
-msgid "Personal timesheet saved"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:361
-#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:255
-msgid ""
-"You are about to leave the planning editing. Unsaved changes will be lost!"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:260
-msgid "SPI"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:436
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:71
-msgid "Send To Subcontractors"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1171
-msgid "a label can not be assigned twice in the same branch"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:30
-msgid "Statistics list "
-msgstr ""
-
-#: org/libreplan/web/common/components/bandboxsearch/BandboxMultipleSearch.java:241
-msgid "format filters are not valid"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1154
-msgid "You do not have permissions to go to edit user window"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:884
-msgid ""
-"Confirm creating a new project version for this scenario and derived. Are "
-"you sure?"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:259
-msgid "Cost Performance Index"
-msgstr ""
-
-#: org/libreplan/web/orders/JiraSynchronizationController.java:186
-#: org/libreplan/web/orders/JiraSynchronizationController.java:239
-#: org/libreplan/web/common/ConfigurationController.java:418
-#: org/libreplan/web/common/ConfigurationController.java:424
-msgid "Cannot connect to JIRA server"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:28
-msgid "Reception date"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:137
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:153
-msgid "Base calendar \"{0}\" saved"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:252
-msgid "BCWP"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:22
-msgid "Cost Categories List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:56
-msgid "Sum of direct imputed hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:54
-msgid "Password settings"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:38
-msgid "Timesheets List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:62
-msgid "Add materials"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:117
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:118
-msgid "the expense sheet must have least a expense sheet line."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/Material.java:105
-msgid "description is not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1319
-msgid ""
-"Spread progress cannot be removed. Please select another progress as spread."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:81
-msgid "quality form item position not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/profiles/profiles.zul:23
-msgid "LibrePlan: Profiles"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:38
-msgid "Code "
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:255
-msgid "Budget At Completion"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:23
-msgid "LibrePlan: Timesheets"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:22
-msgid "Criteria Requirement"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:574
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:612
-msgid "Assigned resources for this task will be deleted. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportQueryController.java:338
-msgid "You do not have permissions to edit this timesheet"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:295
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:518
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:138
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:82
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:141
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:146
-msgid "date not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:33
-msgid "Locations"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:283
-msgid "No worklogs found for \"{0}\" issue"
-msgstr ""
-
-#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:733
-msgid "Start filtering date cannot be empty"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:224
-msgid "date cannot be empty if it is shared by lines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:44
-msgid "Assigned load"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:145
-msgid "number of digits out of range"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:58
-msgid "Expected"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:441
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:72
-msgid "Received From Subcontractors"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:36
-#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:26
-msgid "Category name"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioModel.java:224
-msgid "Could not save the scenario"
-msgstr ""
-
-#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:119
-msgid ""
-"The name is not valid, there is another progress type with the same name. "
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:52
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:59
-msgid "Allocations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:36
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:104
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:53
-msgid "Project Name"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:82
-msgid "scenario"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:239
-#: org/libreplan/web/orders/OrderCRUDController.java:1424
-#: org/libreplan/web/orders/OrderElementTreeController.java:817
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:407
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:779
-#: org/libreplan/web/workreports/WorkReportQueryController.java:138
-#: org/libreplan/web/planner/order/OrderPlanningController.java:367
-#: org/libreplan/web/planner/company/CompanyPlanningController.java:296
-msgid "must be after start date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:211
-msgid "criterion type name not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:133
-msgid "For more details on cron expression click"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:266
-msgid "Delivery dates asked by the subcontractor. "
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:102
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionValue.java:80
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:93
-msgid "value not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:30
-msgid "Inherits up to date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:85
-msgid "name not specified or empty"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1330
-msgid "Confirm change"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:168
-msgid "Delete task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:30
-msgid "options"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:105
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:868
-#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:28
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:81
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:36
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:50
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:57
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:50
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:70
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:48
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:281
-#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:29
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:31
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:267
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:68
-#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:28
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:42
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:37
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:40
-#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:31
-#: libreplan-webapp/src/main/webapp/calendars/_list.zul:31
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:258
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:44
-#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:44
-#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:29
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:26
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:37
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:56
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:109
-#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:39
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:37
-#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:31
-#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:40
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:39
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:83
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:95
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:137
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:178
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:99
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:99
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:140
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:107
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:148
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:99
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:140
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:120
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:89
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:128
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:170
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:88
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:128
-#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:29
-#: libreplan-webapp/src/main/webapp/templates/_advances.zul:39
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:41
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:33
-#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:50
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:38
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:87
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:143
-#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:30
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:63
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:88
-#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:28
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:36
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:52
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:137
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:159
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:110
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:127
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:58
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:174
-#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:36
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:60
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:59
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:52
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:57
-msgid "Operations"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:106
-msgid "Task Code"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:226
-msgid "maximum value of percentagee progress type must be 100"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:80
-msgid "length less than 1"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:77
-msgid "Assign Label"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:154
-msgid "Add profile"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:117
-msgid "Any"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementInExpenseSheetBandboxFinder.java:45
-msgid "Task name (Task code)"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:316
-msgid "A stretch has lower or equal values than the previous stretch"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:25
-#: libreplan-webapp/src/main/webapp/templates/_advances.zul:27
-msgid "Progress assignments"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:408
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:67
-msgid "User Accounts"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1211
-msgid "last sequence code not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:140
-msgid "number of digits not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:140
-msgid "Resources load filtering"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:82
-msgid "Availability"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1637
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:1643
-msgid "please, select a timesheet template type"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:857
-msgid "Done"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:49
-msgid "Print"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:254
-msgid "There are repeated material codes"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:294
-msgid "Password cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:28
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:59
-msgid "Default price"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:130
-msgid "Key for Order \"{0}\" is empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:163
-msgid "Budget hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:86
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:75
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:68
-#: libreplan-webapp/src/main/webapp/planner/order.zul:70
-msgid "Back"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/CriterionsController.java:89
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:473
-msgid "MessagesContainer is needed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:24
-msgid "was successful"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:55
-msgid "Create template from selected task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:352
-msgid "Save passwords in database"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:521
-msgid "The code must be unique."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:500
-msgid ""
-"In personal timesheets, all timesheet lines should be in the same period"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:94
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:97
-msgid "Non Consolidated"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:114
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:76
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:84
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:76
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:97
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:65
-msgid "Filter by labels"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/requirements/entities/CriterionRequirement.java:68
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:206
-msgid "criterion not specified"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/UserBandboxFinder.java:47
-msgid "Full name"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:168
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:309
-msgid "At least one stretch is needed"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:220
-msgid "Unlimited"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:68
-msgid "Inherited exception"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:469
-msgid "Invalid queue element"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:225
-msgid "Timesheet removed successfully"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:306
-msgid "please select a user to bound"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:92
-msgid ""
-"Estimated start date for the task (press enter in textbox to open calendar "
-"popup or type in date directly)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/externalcompanies.zul:23
-msgid "LibrePlan: Companies"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:53
-msgid "Subcontrated task"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:486
-msgid "resource type does not allow enabled criteria"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:147
-msgid "Create project from Template"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:166
-msgid "There is a margin of {0} days with the project global deadline ({1}%)."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:218
-msgid "Project type"
-msgstr ""
-
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:763
-msgid "Date must be inside visualization area"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/templates.zul:22
-msgid "LibrePlan: Templates"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resourceload/resourceload.zul:22
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:22
-#: libreplan-webapp/src/main/webapp/planner/main.zul:22
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:22
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:22
-#: libreplan-webapp/src/main/webapp/planner/resources_use.zul:22
-#: libreplan-webapp/src/main/webapp/planner/order.zul:22
-msgid "LibrePlan: Scheduling"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:22
-msgid "LibrePlan: Send To Customers"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:436
-msgid "The timesheet line codes must be unique."
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:859
-msgid "Task finished"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:75
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:160
-msgid "New"
-msgstr ""
-
-#: org/libreplan/web/planner/TaskElementAdapter.java:1124
-#: org/libreplan/web/planner/TaskElementAdapter.java:1139
-msgid "{0} not supported yet"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:77
-msgid "Application URI"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:64
-msgid "Date Finish"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:91
-msgid "Original"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:169
-msgid "Imputed hours"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:127
-msgid "Product code should not be empty"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:381
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:45
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:68
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:86
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:66
-#: libreplan-webapp/src/main/webapp/planner/order.zul:106
-msgid "Percentage"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:52
-msgid "Select destination"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:146
-msgid "Percentage of estimated budget hours / hours consumed"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:339
-msgid "Cannot connect to LDAP server"
-msgstr ""
-
-#: org/libreplan/web/resourceload/ResourceLoadController.java:840
-msgid "Show all elements"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:180
-msgid "Create exception"
-msgstr ""
-
-#: org/libreplan/web/dashboard/GlobalProgressChart.java:61
-msgid "By all tasks hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:29
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:41
-msgid "Cron expression"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:34
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:23
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:51
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:29
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:83
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:54
-msgid "Filter"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:271
-msgid "Bound user does not have the proper role"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:29
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:72
-msgid "Days from Beginning to Deadline"
-msgstr ""
-
-#: org/libreplan/web/resourceload/ResourceLoadController.java:965
-#: org/libreplan/web/planner/order/OrderPlanningModel.java:718
-#: org/libreplan/web/planner/company/CompanyPlanningModel.java:351
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:49
-msgid "Load"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/reassign.zul:30
-msgid "Reassigning"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1347
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1369
-msgid ""
-"Invalid value. Value must be greater than the value of previous progress."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:141
-msgid "The admin's account password remains the default one. This is insecure"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:115
-msgid "Enable/Disable"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:128
-msgid "cost assignment's resource not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:65
-msgid "Dependencies"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:253
-msgid "CV"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:200
-msgid "Done {0} of {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:231
-msgid "Inherited from parent calendar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:155
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:117
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:125
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:117
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:147
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:105
-msgid "Filter by criteria"
-msgstr ""
-
-#: org/libreplan/web/labels/LabelTypeModel.java:280
-msgid "The name of the label is empty."
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/ResourceAllocationCommand.java:71
-msgid "Resource allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:168
-msgid "Material categories"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:259
-msgid "CPI"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:377
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:84
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:136
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:157
-msgid "Position"
-msgstr ""
-
-#: org/libreplan/web/users/settings/PasswordController.java:96
-msgid "passwords can not be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:217
-msgid "Timesheet lines"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:499
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:39
-msgid "Task Scheduling Status In Project"
-msgstr ""
-
-#: org/libreplan/web/planner/TaskElementAdapter.java:909
-msgid "Hours cost: {0}, Expenses cost: {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:30
-#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:35
-msgid "Select parent calendar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:112
-msgid "Project view"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:102
-msgid "cost assignment's start date not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:127
-msgid "Total expenses"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:420
-msgid "project calendar not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:49
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:228
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:165
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:187
-#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:195
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:96
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:188
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:168
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:217
-#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:178
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:37
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:37
-msgid "Show"
-msgstr ""
-
-#: org/libreplan/web/subcontract/FilterCommunicationEnum.java:28
-msgid "Not Reviewed"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionAdminController.java:97
-msgid "Question"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:67
-msgid "Group name"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:224
-msgid "User already bound to other worker"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:506
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:516
-msgid "Repeated Project code {0} in Project {1}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:115
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:147
-msgid "Day of month"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:36
-msgid "Edit Template"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:42
-msgid "Timesheet data"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:149
-msgid "company name must be unique. Company name already used"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:77
-msgid "percentage not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/Profile.java:89
-msgid "profile name is already being used by another profile"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:378
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:31
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:75
-msgid "Timesheet Lines List"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:493
-msgid "there are repeated description values in the timesheet lines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:37
-msgid "Shrink to fit page width"
-msgstr ""
-
-#: org/libreplan/web/common/components/bandboxsearch/BandboxMultipleSearch.java:229
-msgid "filter already exists"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:476
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:39
-msgid "Work And Progress Per Project"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:400
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:442
-msgid "Edit Worker: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:47
-msgid "Date last progress reported"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:468
-msgid ""
-"Starting date cannot be empty because there is a task with constraint \"as "
-"soon as possible\""
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:94
-msgid "quality form item percentage not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:391
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:235
-msgid "budget not specified"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:224
-msgid "Registration response with empty refs"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:47
-msgid "Task quality form name"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:49
-msgid "Selected node"
-msgstr ""
-
-#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:488
-msgid "( max: {0} )"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/ResourceCalendar.java:78
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:216
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:164
-msgid "resource not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:237
-msgid "resource cannot be empty if it is shared by lines"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:431
-msgid "Effort must be greater than zero"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:45
-msgid "Customer reference code"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:73
-msgid "Node without children"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:108
-msgid "Expense sheet \"{1}\" could not be deleted, it was already removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:92
-msgid "Latest date"
-msgstr ""
-
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:863
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:77
-#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:112
-#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:70
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:450
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:84
-#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:64
-#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:89
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:133
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:162
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:102
-#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:46
-#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:45
-#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:90
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:48
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:97
-#: libreplan-webapp/src/main/webapp/resources/worker/virtualWorkers.zul:41
-#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:45
-#: libreplan-webapp/src/main/webapp/resources/worker/worker.zul:42
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:94
-#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:41
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:125
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:131
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:59
-#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:38
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:118
-#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:37
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:232
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:184
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:180
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:91
-msgid "Save"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:306
-msgid "Root calendar"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:256
-msgid "Estimate At Completion"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:980
-msgid "Do you want to remove bound user \"{0}\" too?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:257
-msgid "Entity type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:43
-msgid "Show money cost bar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:108
-msgid "Current selection"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:389
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:783
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:32
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:84
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:46
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:69
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:87
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:50
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:154
-#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:28
-#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:43
-#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:43
-#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:43
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:98
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:69
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:118
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:181
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:48
-#: libreplan-webapp/src/main/webapp/planner/order.zul:107
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:170
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:69
-msgid "Date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:118
-msgid "Sum of expenses imputed in children tasks"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:64
-msgid "Work done until ending date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:89
-#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:31
-msgid "Authentication type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:47
-msgid "Please remember that only saved changes will be printed"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:480
-msgid "Extra"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:34
-msgid "Import Project"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:114
-#: org/libreplan/web/users/UserCRUDController.java:115
-#: org/libreplan/web/users/UserCRUDController.java:407
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:156
-msgid "No"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:31
-msgid "Stretches function configuration"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:537
-msgid "The code cannot be empty and it must be unique."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:24
-msgid "LibrePlan: Criteria"
-msgstr ""
-
-#: org/libreplan/importers/OrderImporterMPXJ.java:660
-msgid "Linked calendar not found"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:234
-msgid "{0} \"{1}\" saved"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:27
-msgid "name"
-msgstr ""
-
-#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:112
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:115
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:106
-msgid "This project has already been added."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:41
-msgid "Planned workable days"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:161
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:199
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:225
-msgid "Normal Effort"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:478
-msgid ""
-"only one timesheet line per day and task is allowed in personal timesheets"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:77
-msgid "Accumulated hours chart"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:70
-#: org/libreplan/web/common/components/EffortDurationPicker.java:62
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:81
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:849
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:34
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:35
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:36
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:154
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:111
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:146
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:37
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:114
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:72
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:34
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:82
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:54
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:72
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:81
-msgid "Hours"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:414
-msgid "Job is scheduled/unscheduled"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:103
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:64
-#: libreplan-webapp/src/main/webapp/orders/_list.zul:31
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:134
-#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:52
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:46
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:54
-msgid "Deadline"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:54
-msgid "Upload Project"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderBandboxFinder.java:44
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:54
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:51
-msgid "Project name"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:442
-msgid "Queue-based resource assignation"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1235
-msgid ""
-"Progress measurements that are reported by quality forms cannot be removed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:51
-msgid "Criterion requirement"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:41
-msgid "Administration"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:84
-msgid "cron expression not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:40
-msgid "Worked hours"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:22
-msgid "Quality Forms List"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:88
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:102
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:133
-#: libreplan-webapp/src/main/webapp/planner/main.zul:66
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:89
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:81
-#: libreplan-webapp/src/main/webapp/planner/reassign.zul:48
-#: libreplan-webapp/src/main/webapp/planner/order.zul:128
-#: libreplan-webapp/src/main/webapp/planner/order.zul:163
-msgid "Accept"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:573
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1020
-msgid "no"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderModel.java:709
-#: org/libreplan/web/planner/TaskElementAdapter.java:891
-#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:42
-msgid "Hours invested"
-msgstr ""
-
-#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:118
-#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:139
-#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:113
-msgid "Please, select a project"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:122
-msgid "Add task"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:289
-msgid "The hour cost codes must be unique."
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:252
-msgid "Budgeted Cost Work Performed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:33
-msgid "No Allocations have been done"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:183
-msgid ""
-"interaction fields are empty and company is marked as interact with "
-"applications"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:33
-msgid "Communications From Customers"
-msgstr ""
-
-#: org/libreplan/web/common/BaseCRUDController.java:331
-msgid "{0} \"{1}\" could not be deleted, it was already removed"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:277
-msgid "Scheduling or unscheduling of jobs for this connector is not completed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:111
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:30
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:30
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:85
-msgid "Unit type"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:211
-msgid "Project: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:387
-msgid "Role property"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:221
-msgid "Criteria: {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:135
-msgid "Generate code for"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:226
-msgid "subcontratation date not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:88
-msgid "Group by weeks"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:120
-msgid "Week {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:44
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:36
-msgid "New expense sheet"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1104
-msgid "dates must be sorted and cannot overlap"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/LimitingResourcesTabCreator.java:96
-#: org/libreplan/web/planner/tabs/LimitingResourcesTabCreator.java:117
-msgid "Queue-based Resources Planning"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Connector.java:100
-msgid "connector name is already being used"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:180
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskDeadlineViolationStatusEnum.java:36
-msgid "On schedule"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:89
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:39
-msgid "Show progress"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:308
-msgid "There are repeated description values in the timesheet "
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:662
-msgid "{0} sequences"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:87
-#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:48
-#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:94
-msgid "Save and Continue"
-msgstr ""
-
-#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:260
-msgid "Schedule Performance Index"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:52
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:807
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:667
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:23
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:150
-#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:139
-#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:93
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:193
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:48
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:127
-#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:167
-msgid "Task"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:91
-msgid "Earliest date"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:382
-#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:22
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:63
-msgid "Expenses"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:89
-msgid "Create and assign label"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:47
-msgid "Gantt charts"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:27
-msgid "Heading"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:73
-msgid "Priority"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:281
-msgid "delivery date not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/TaskElementAdapter.java:843
-msgid "All workers"
-msgstr ""
-
-#: org/libreplan/web/tree/TreeComponent.java:116
-msgid "Scheduling state"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:111
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:122
-msgid "Total hours task"
-msgstr ""
-
-#: org/libreplan/web/orders/OrdersTreeComponent.java:105
-msgid ""
-"Estimated end date for the task (press enter in textbox to open calendar "
-"popup or type in date directly)"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderElementInExpenseSheetBandboxFinder.java:45
-#: org/libreplan/web/common/components/finders/OrderInExpenseSheetBandboxFinder.java:44
-msgid "Project name (Project code)"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1210
-msgid "Queue-based assignment"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:56
-msgid "Quality form type"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:432
-msgid "last task sequence code not specified"
-msgstr ""
-
-#: org/libreplan/web/planner/reassign/ReassignCommand.java:138
-msgid "{0} reassignations finished"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:66
-msgid "job group not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:40
-msgid "Data"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:421
-msgid ""
-"In the heading part, index labels and fields must be unique and consecutive"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:99
-msgid "Allowed values"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:420
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:690
-msgid "Other"
-msgstr ""
-
-#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:403
-msgid "At least one HoursGroup is needed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:112
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:31
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:31
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:84
-msgid "Unit price"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:236
-msgid "item"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:668
-msgid "A description field with the same name already exists."
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:322
-#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:46
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:53
-msgid "Calendars"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:92
-#: org/libreplan/importers/ExportTimesheetsToTim.java:135
-#: org/libreplan/importers/ImportRosterFromTim.java:124
-msgid "Tim connector not found"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:279
-#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:36
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:55
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:61
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:38
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:82
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:60
-#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:57
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:125
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:45
-#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:61
-msgid "End date"
-msgstr ""
-
-#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:757
-msgid "Start filtering date must be before than end filtering date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_synchronizationInfo.zul:20
-msgid "LibrePlan: Synchronization info"
-msgstr ""
-
-#: org/libreplan/web/orders/DetailsOrderElementController.java:128
-msgid "must be after starting date"
-msgstr ""
-
-#: org/libreplan/web/subcontract/ReportAdvancesController.java:199
-#: org/libreplan/web/subcontract/SubcontractedTasksController.java:207
-msgid "Send"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:42
-msgid "Load due to other assignments"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:32
-msgid "Show only current satisfied criteria"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:199
-msgid "last label sequence code not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:50
-msgid "Subcontracting communication date"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:860
-#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:207
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:181
-#: org/libreplan/web/workreports/WorkReportQueryController.java:250
-#: org/libreplan/web/resourceload/ResourceLoadController.java:839
-#: org/libreplan/web/subcontract/FilterCommunicationEnum.java:28
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:75
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:76
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:27
-msgid "All"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:102
-msgid "Add new criterion requirement"
-msgstr ""
-
-#: org/libreplan/web/materials/UnitTypeController.java:153
-msgid "The code is not valid. There is another unit type with the same code"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:69
-msgid "hours type"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:413
-#: org/libreplan/web/users/ProfileCRUDController.java:124
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:68
-msgid "Profiles"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:252
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:280
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:109
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:126
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:48
-msgid "Communication date"
-msgstr ""
-
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:312
-msgid ""
-"Another task in the same branch is already reporting progress for this "
-"quality form"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:134
-msgid "New user"
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesController.java:263
-msgid "calendar not specified"
-msgstr ""
-
-#: org/libreplan/web/orders/JiraSynchronizationController.java:205
-msgid "No JIRA issues to import"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:322
-msgid "from {0}"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeModel.java:344
-msgid "Name of criterion is empty."
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationModel.java:206
-msgid "At least one {0} sequence is needed"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:27
-msgid "Task Information"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:462
-msgid "Assign element to queue manually"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:42
-msgid "Main preferences"
-msgstr ""
-
-#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:258
-msgid "Calendar Exception Day"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:130
-msgid "Exceptions"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:123
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:149
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:224
-msgid "Day of week"
-msgstr ""
-
-#: org/libreplan/web/orders/OrderCRUDController.java:834
-#: org/libreplan/web/orders/OrderCRUDController.java:979
-#: org/libreplan/web/orders/OrderCRUDController.java:1039
-#: org/libreplan/web/orders/OrderCRUDController.java:1050
-#: org/libreplan/web/orders/OrderCRUDController.java:1083
-#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:160
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:331
-#: org/libreplan/web/resourceload/ResourceLoadController.java:405
-#: org/libreplan/web/resourceload/ResourceLoadController.java:415
-#: org/libreplan/web/planner/taskedition/EditTaskController.java:361
-#: org/libreplan/web/planner/order/SaveCommandBuilder.java:352
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:717
-msgid "Information"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:528
-msgid "resource has to be bound to a user in personal timesheets"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:387
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:531
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:64
-msgid "Cost Categories"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:60
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:61
-msgid "Split assignment"
-msgstr ""
-
-#: org/libreplan/web/common/EffortDurationBox.java:49
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:212
-#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:288
-msgid "Invalid Effort Duration"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:134
-msgid "here"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:60
-msgid "Create Virtual Worker"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/AdvancedAllocationTabCreator.java:156
-#: org/libreplan/web/planner/tabs/AdvancedAllocationTabCreator.java:236
-msgid "Advanced Allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:51
-msgid "Users authorization"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:40
-msgid "The page that you are requesting does not exist."
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:297
-msgid "Import project"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:426
-msgid ""
-"Number of hours is not properly calculated according to start date and end "
-"date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:86
-msgid "Change scenario"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1454
-msgid "Stretches list"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:92
-msgid "Select scenario"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:43
-msgid "From date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:41
-msgid "Basic data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:27
-#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:67
-msgid "Delay from beginning (days)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:28
-#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:70
-#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:219
-msgid "Add new row"
-msgstr ""
-
-#: org/libreplan/importers/ExportTimesheetsToTim.java:203
-msgid "Unable to crate time registration for request"
-msgstr ""
-
-#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:515
-msgid "Code cannot be empty."
-msgstr ""
-
-#: org/libreplan/web/orders/TreeElementOperationsController.java:257
-msgid "Operation cannot be done"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:35
-msgid "Communications To Customers"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:68
-msgid "Unindent selected task"
-msgstr ""
-
-#: org/libreplan/web/materials/MaterialsController.java:526
-msgid "Cannot delete that material because it is assigned to a project."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:367
-msgid "At least one hours group is needed for each task"
-msgstr ""
-
-#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:350
-msgid ""
-"This resource allocation type is incompatible. The task has an associated "
-"order element which has a progress that is of type subcontractor. "
-msgstr ""
-
-#: org/libreplan/web/orders/CriterionRequirementWrapper.java:222
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:99
-msgid "Invalidate"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/editTask.zul:65
-msgid "Task properties"
-msgstr ""
-
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:541
-msgid "No JIRA issues found for key {0}"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:236
-msgid "Expenses cost"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:766
-msgid "The field name must be unique and not empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:105
-msgid "Up"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:643
-msgid "{0} already assigned to resource allocation list"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:330
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1111
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1174
-msgid ""
-"Progress Measurement cannot be deleted. Progress Measurement already "
-"consolidated"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:331
-msgid "Scheduling saved"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:128
-msgid "All changes will be lost. Are you sure?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:40
-msgid "Active period from"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:149
-msgid "Time period saved"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionTreeController.java:306
-msgid "Indent"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:826
-msgid "Text field"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/template.zul:109
-msgid "Log out"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:181
-msgid "base not specified"
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesModel.java:317
-msgid "Already exists another template with the same name"
-msgstr ""
-
-#: org/libreplan/web/users/dashboard/MyTasksAreaController.java:146
-msgid "Track time"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1177
-msgid "Workers limit reached"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:702
-msgid "Inh"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:428
-msgid ""
-"Default calendar cannot be removed. Please, change the default calendar in "
-"the Main Settings window before."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:27
-msgid "Overload due to other assignments"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:49
-msgid "Duration"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:68
-msgid "Dedication chart"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/scenarios/scenarios.zul:23
-msgid "LibrePlan: Scenarios Management"
-msgstr ""
-
-#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:170
-#: org/libreplan/web/reports/OrderCostsPerResourceController.java:213
-#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:343
-#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:208
-#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:165
-msgid "This Criterion has already been added."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:104
-msgid "Appropriative allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:33
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:58
-msgid "Authorize"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:455
-msgid "Communications"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:292
-#: org/libreplan/web/common/JobSchedulerController.java:293
-#: org/libreplan/web/limitingresources/LimitingResourcesController.java:461
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:77
-msgid "Manual"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:349
-msgid "the project must have a start date"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeModel.java:414
-msgid "There is another timesheet template with the same name"
-msgstr ""
-
-#: org/libreplan/web/resources/criterion/CriterionsModel.java:217
-msgid "Criterion cannot be empty"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionController.java:343
-msgid "Length percentage should be between 0 and 100"
-msgstr ""
-
-#: org/libreplan/web/scenarios/TransferOrdersModel.java:148
-msgid "Please, select a destination scenario"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:525
-msgid "Change Password"
-msgstr ""
-
-#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:160
-msgid ""
-"Could not save time period. Time period overlaps with another non-compatible"
-" time period"
-msgstr ""
-
-#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:143
-#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:456
-msgid "Confirm deleting this hour cost. Are you sure?"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:759
-msgid "Calculated progress cannot be removed"
-msgstr ""
-
-#: org/libreplan/web/orders/TreeElementOperationsController.java:254
-msgid ""
-"Templates can only be created out of existent tasks.You are trying to create a template out of a new task.\n"
-"Please save your project before proceeding."
-msgstr ""
-
-#: org/libreplan/web/templates/OrderTemplatesController.java:224
-#: org/libreplan/web/templates/OrderTemplatesController.java:242
-msgid "Template saved"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:593
-msgid "Exception: {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:75
-msgid "job name not specified"
-msgstr ""
-
-#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:209
-msgid "Cannot be higher than Ending Date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:28
-msgid "User data"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:106
-#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:139
-msgid "Projects List"
-msgstr ""
-
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:93
-#: org/libreplan/web/orders/labels/AssignedLabelsController.java:139
-#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:174
-msgid "already assigned"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportTypeModel.java:423
-msgid "Code cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:93
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:96
-#: libreplan-webapp/src/main/webapp/planner/order.zul:108
-msgid "Consolidated"
-msgstr ""
-
-#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:459
-msgid "Do you want to split the material assignment {0}?"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:44
-msgid "Current value"
-msgstr ""
-
-#: org/libreplan/web/orders/TreeElementOperationsController.java:244
-msgid "Confirm create template"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTreeComponent.java:72
-msgid "Delete Template element"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/machines.zul:22
-msgid "LibrePlan: Machines"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:36
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:35
-#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:37
-msgid "Apply filtering to tasks satisfying required criteria"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:22
-msgid "Work Hours Types List"
-msgstr ""
-
-#: org/libreplan/web/templates/TemplatesTree.java:43
-#: org/libreplan/web/templates/TemplatesTree.java:51
-msgid "New Description"
-msgstr ""
-
-#: org/libreplan/web/common/components/NewAllocationSelector.java:75
-msgid "generic machines allocation"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:130
-msgid "Assign materials"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:86
-msgid "position not specified"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:171
-msgid "type of work hours for JIRA connector cannot be disabled"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:923
-msgid ""
-"Spread progress cannot be changed if there is a consolidation in any "
-"progress assignment from root task"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:153
-msgid "material category name has to be unique. It is already used"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:28
-msgid "Company data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:47
-msgid "Apply changes and continue editing"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:123
-msgid "No tasks available yet"
-msgstr ""
-
-#: org/libreplan/web/planner/order/OrderPlanningController.java:328
-msgid "filtering"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:285
-msgid "description value: the timesheet has some description field missing"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/AllocationRow.java:824
-msgid "there are no valid periods for this calendar"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:58
-msgid "Duration (days)"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:60
-msgid "Cannot calculate charts for current data"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:113
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:33
-#: libreplan-webapp/src/main/webapp/materials/materials.zul:86
-msgid "Category"
-msgstr ""
-
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1521
-msgid "It cannot be empty"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:38
-msgid "Unit name"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:527
-msgid "Personal area"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:153
-msgid "The end date cannot be before the start date"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:36
-msgid "Human hours per machine working hour within configuration unit"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:66
-msgid "Connector"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:177
-msgid "Last stretch should have 100% for length and amount of work"
-msgstr ""
-
-#: org/libreplan/web/users/UserCRUDController.java:273
-#: org/libreplan/web/users/settings/PasswordController.java:99
-msgid "passwords don't match"
-msgstr ""
-
-#: org/libreplan/web/common/JobSchedulerController.java:434
-msgid "Job is deleted from scheduler"
-msgstr ""
-
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1295
-msgid "Add measure"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:149
-msgid "type of work hours for personal timesheets cannot be disabled"
-msgstr ""
-
-#: org/libreplan/web/users/OrderAuthorizationController.java:109
-msgid ""
-"Could not add those authorizations to user {0} because they were already "
-"present."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:219
-msgid "Add Exception"
-msgstr ""
-
-#: org/libreplan/web/common/components/finders/OrderBandboxFinder.java:44
-#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
-#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:35
-#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:44
-#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:50
-msgid "Project code"
-msgstr ""
-
-#: org/libreplan/web/resources/machine/MachineCRUDController.java:552
-msgid "Machine was already removed"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/streches/StretchesFunctionModel.java:172
-msgid "Some stretch has higher or equal values than the previous stretch"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:372
-msgid "Role search strategy"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:278
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:107
-msgid "Save date"
-msgstr ""
-
-#: org/libreplan/web/common/TemplateController.java:244
-msgid ""
-" of LibrePlan is available. Please check next link for more information:"
-msgstr ""
-
-#: org/libreplan/importers/JiraTimesheetSynchronizer.java:108
-#: org/libreplan/importers/JiraOrderElementSynchronizer.java:517
-msgid "Synchronization"
-msgstr ""
-
-#: org/libreplan/web/common/CustomMenuController.java:425
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:288
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:33
-msgid "Configuration"
-msgstr ""
-
-#: org/libreplan/web/planner/allocation/FormBinder.java:637
-msgid "it must be greater than zero"
-msgstr ""
-
-#: org/libreplan/web/orders/ProjectDetailsController.java:267
-#: org/libreplan/web/orders/DetailsOrderElementController.java:109
-msgid "Must be after 2010!"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/layout/login.zul:144
-msgid "is not supported for its use with LibrePlan."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:99
-msgid "passed not specified"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:235
-msgid "Customer reference"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:154
-msgid "End Date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:471
-msgid "criterion type does not allow hierarchy"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:60
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:68
-msgid "Advanced search"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:171
-msgid "port not specified"
-msgstr ""
-
-#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:339
-msgid "Quality Form"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:32
-msgid "Overload due to current project"
-msgstr ""
-
-#: org/libreplan/web/dashboard/DashboardController.java:219
-msgid "Task Completation Lead/Lag"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:59
-#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:60
-msgid "Split"
-msgstr ""
-
-#: org/libreplan/web/orders/TreeElementOperationsController.java:243
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1139
-#: org/libreplan/web/users/UserCRUDController.java:438
-msgid "Unsaved changes will be lost. Would you like to continue?"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportModel.java:591
-msgid "Show all"
-msgstr ""
-
-#: org/libreplan/web/scenarios/ScenarioModel.java:132
-msgid "You cannot remove a scenario with derived scenarios"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:248
-msgid "external company should be subcontractor"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:470
-msgid ""
-"description value: the timesheet has not assigned the description field"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:233
-msgid "Select entity"
-msgstr ""
-
-#: org/libreplan/web/limitingresources/QueueComponent.java:485
-msgid "Unassign"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:241
-msgid "a personal expense sheet must have the same resource in all the lines"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:114
-msgid "items cannot be checked until the previous items are checked before."
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:32
-msgid "Queue Element Information"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/common/event_error.zul:25
-#: libreplan-webapp/src/main/webapp/common/error.zul:30
-msgid "Message - {0}"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:127
-msgid "last expense sheet line sequence code not specified"
-msgstr ""
-
-#: org/libreplan/web/workreports/WorkReportCRUDController.java:853
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:34
-#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:116
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:47
-msgid "Hours type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:56
-msgid "Previous"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:74
-msgid "Resource allocation type"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:49
-#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:66
-msgid "Report progress"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/common/IntegrationEntity.java:110
-msgid "code is already used"
-msgstr ""
-
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:255
-#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:273
-msgid "Project Scheduling"
-msgstr ""
-
-#: org/libreplan/web/orders/TimSynchronizationController.java:153
-msgid "Exporting timesheets to Tim failed. Check the Tim connector"
-msgstr ""
-
-#: org/libreplan/web/common/ConfigurationController.java:414
-msgid "JIRA connection was successful"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:79
-msgid "Found resources"
-msgstr ""
-
-#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:31
-#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:32
-msgid "Assigned criteria"
-msgstr ""
+"Користувачі LDAP не можуть змінити пароль, якщо увімкнено автентифікацію "
+"LDAP. Зверніться до одного з адміністраторів"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:157
+msgid "Report data"
+msgstr "Дані звіту"
 
 #: org/libreplan/importers/JiraOrderElementSynchronizer.java:171
 #: org/libreplan/importers/JiraOrderElementSynchronizer.java:533
 msgid "Synchronization order {0}"
-msgstr ""
+msgstr "Синхронізація проєкту {0}"
 
-#: org/libreplan/web/montecarlo/MonteCarloModel.java:70
-#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:69
-msgid "Critical path"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:163
+msgid "Unexpected: {0}"
+msgstr "Неочікувано: {0}"
 
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:510
-msgid "You do not have permissions to create new users"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:60
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:66
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:109
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:66
+msgid "Project Code"
+msgstr "Код проєкту"
 
-#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:29
-msgid "Export options"
-msgstr ""
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:32
+#: org/libreplan/web/common/components/finders/ResourceBandboxFinder.java:46
+#: org/libreplan/web/common/components/finders/ResourceFilterEnumByResourceAndCriterion.java:31
+#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
+#: org/libreplan/web/common/components/finders/ResourceAllocationFilterEnum.java:30
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:829
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:32
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:85
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:73
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:208
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:48
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:106
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:85
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:99
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:157
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:182
+msgid "Resource"
+msgstr "Ресурс"
 
-#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:26
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:42
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:66
-#: libreplan-webapp/src/main/webapp/users/_editUser.zul:160
-msgid "Profile name"
-msgstr ""
+#: org/libreplan/web/orders/OrdersTreeComponent.java:84
+#: org/libreplan/web/common/CustomMenuController.java:413
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:216
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:23
+msgid "Expenses"
+msgstr "Витрати"
 
-#: org/libreplan/web/common/ConfigurationController.java:383
-msgid "Tim connection was successful"
-msgstr ""
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:669
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:697
+msgid "This progress type cannot be modified"
+msgstr "Цей тип прогресу не можна змінити"
 
-#: org/libreplan/web/resources/worker/WorkerCRUDController.java:862
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceType.java:30
-msgid "Normal resource"
-msgstr ""
+#: org/libreplan/web/dashboard/DashboardController.java:186
+msgid "No deadline"
+msgstr "Без кінцевого терміну"
 
-#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:123
-msgid "{0} 1st fortnight"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:501
+msgid "Criteria of this criterion type have been assigned to some resource."
+msgstr "Критерії цього типу критерію були призначені деяким ресурсам."
 
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:90
-#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:108
-msgid "Deliver date"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:288
+msgid "Worker saved"
+msgstr "Працівника збережено"
 
-#: org/libreplan/web/planner/TaskElementAdapter.java:904
-msgid "Budget: {0}, Consumed: {1} ({2}%)"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:108
+msgid "Resources matching selected criteria"
+msgstr "Ресурси, що відповідають обраним критеріям"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:161
-msgid "host not specified"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:283
+msgid "Select entity"
+msgstr "Обрати сутність"
 
-#: org/libreplan/web/resources/worker/CriterionsMachineController.java:214
-msgid "End date is not valid, the new end date must be after the start date"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:34
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:29
+msgid "Overload"
+msgstr "Перевантаження"
 
-#: org/libreplan/web/planner/adaptplanning/AdaptPlanningCommand.java:60
-msgid "Adapt planning according to timesheets"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderElementTemplate.java:488
+msgid "template name is already in use"
+msgstr "назва шаблону вже використовується"
 
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:48
-msgid "Calculated"
-msgstr ""
+#: org/libreplan/web/materials/MaterialsModel.java:282
+msgid "both {0} of category {1} and {2} of category {3} have the same code"
+msgstr "обидва {0} категорії {1} та {2} категорії {3} мають однаковий код"
 
-#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:97
-msgid "Search"
-msgstr ""
+#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:94
+msgid "Expense sheet \"{1}\" could not be deleted, it was already removed"
+msgstr "Аркуш витрат \"{1}\" не вдалося видалити, його вже було видалено"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:75
+msgid "Authorizations"
+msgstr "Авторизації"
+
+#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:380
+msgid "Delete item {0}. Are you sure?"
+msgstr "Видалити елемент {0}. Ви впевнені?"
 
 #: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:56
-#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:27
-#: libreplan-webapp/src/main/webapp/orders/_edition.zul:57
-msgid "Task quality forms"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:66
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:70
+msgid "Criterion Requirement"
+msgstr "Вимога критерію"
 
-#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:239
-msgid "There are repeated material category codes"
-msgstr ""
+#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:148
+msgid "Time period saved"
+msgstr "Часовий період збережено"
 
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1179
-msgid "You have exceeded the maximum limit of resources"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:44
+msgid "Lines"
+msgstr "Рядки"
 
-#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:82
-msgid "Criterion requirements"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:78
+msgid "percentage not specified"
+msgstr "відсоток не вказано"
 
-#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:768
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:58
+msgid "Create template from selected task"
+msgstr "Створити шаблон з обраного завдання"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:415
+#: org/libreplan/web/logs/RiskLogCRUDController.java:397
+#: libreplan-webapp/src/main/webapp/logs/_logs.zul:42
+msgid "Issue logs"
+msgstr "Журнали проблем"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:100
+msgid "Availability ratio"
+msgstr "Коефіцієнт доступності"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/IntegrationEntity.java:106
+msgid "code is already used"
+msgstr "код вже використовується"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:235
+msgid "Total calculated budget"
+msgstr "Загальний розрахований бюджет"
+
+#: org/libreplan/web/workreports/WorkReportTypeModel.java:427
 msgid ""
-"Subcontractor values are read only because they were reported by the "
-"subcontractor company"
+"Value is not valid.\n"
+" Code cannot contain chars like '_'."
 msgstr ""
+"Значення недійсне.\n"
+" Код не може містити символи на кшталт '_'."
 
-#: libreplan-webapp/src/main/webapp/common/configuration.zul:79
-msgid "Personal timesheets peridocity"
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:44
+msgid "External load"
+msgstr "Зовнішнє завантаження"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:464
+msgid "Remove queue-based resource element"
+msgstr "Видалити елемент ресурсу на основі черги"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:271
+msgid "Critical"
+msgstr "Критичний"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:101
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:84
+msgid "Created by"
+msgstr "Створено"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:32
+msgid "Overload due to current project"
+msgstr "Перевантаження через поточний проєкт"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:49
+msgid ""
+"If you reached this page from another page of LibrePlan please notify us in "
+"order to fix it as soon as possible."
 msgstr ""
+"Якщо ви потрапили на цю сторінку з іншої сторінки LibrePlan, будь ласка, "
+"повідомте нас, щоб ми могли виправити це якомога швидше."
 
-#: org/libreplan/web/resourceload/ResourceLoadController.java:554
-msgid "To"
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:125
+msgid "Assigned to"
+msgstr "Призначено для"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector_combo.zul:25
+msgid "Select criteria or resources"
+msgstr "Обрати критерії або ресурси"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:193
+msgid ""
+"Progress measurements must have a value lower than their following progress "
+"measurements."
 msgstr ""
+"Вимірювання прогресу повинні мати значення менше за наступні вимірювання "
+"прогресу."
 
-#: org/libreplan/web/common/ConfigurationController.java:451
-#: org/libreplan/web/common/ConfigurationController.java:763
-#: org/libreplan/web/common/ConfigurationController.java:861
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:140
+msgid ""
+"Roles of LDAP users cannot be managed because LDAP is enabled and LDAP roles "
+"are being used."
+msgstr ""
+"Ролями користувачів LDAP неможливо керувати, оскільки LDAP увімкнено та "
+"використовуються ролі LDAP."
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:86
+msgid "value must be greater or equal than 0"
+msgstr "значення повинно бути більше або дорівнювати 0"
+
+#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:411
+msgid "At least one HoursGroup is needed"
+msgstr "Потрібна принаймні одна група годин"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:899
+msgid "{0} could not be allocated. Cannot allocate more than one resource"
+msgstr ""
+"{0} не вдалося розподілити. Неможливо розподілити більше одного ресурсу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:152
+msgid "The end date cannot be before the start date"
+msgstr "Дата завершення не може бути раніше за дату початку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:235
+msgid "maximum value must be greater than zero"
+msgstr "максимальне значення повинно бути більше нуля"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:165
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:318
+msgid "At least one stretch is needed"
+msgstr "Потрібне принаймні одне розтягнення"
+
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:31
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:93
+msgid "Delay from beginning (days)"
+msgstr "Затримка від початку (дні)"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:90
+msgid "Resources usage"
+msgstr "Використання ресурсів"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:84
+msgid "Material assignments"
+msgstr "Призначення матеріалів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:259
+msgid ""
+"closckStart:the clockStart must be not null if number of hours is calcultate "
+"by clock"
+msgstr ""
+"clockStart: час початку за годинником не повинен бути порожнім, якщо "
+"кількість годин розраховується за годинником"
+
+#: org/libreplan/web/common/components/bandboxsearch/BandboxMultipleSearch.java:241
+msgid "format filters are not valid"
+msgstr "фільтри формату недійсні"
+
+#: org/libreplan/web/users/OrderAuthorizationController.java:93
+msgid "No authorizations were added because you did not select any."
+msgstr "Жодної авторизації не додано, оскільки ви не обрали жодної."
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1146
+msgid "Workers limit reached"
+msgstr "Досягнуто ліміту працівників"
+
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:24
+msgid "Synchronization order elements with JIRA issues was successful"
+msgstr "Синхронізацію елементів проєкту з проблемами JIRA виконано успішно"
+
+#: org/libreplan/web/planner/calendar/CalendarAllocationCommand.java:55
+#: libreplan-webapp/src/main/webapp/planner/order.zul:146
+msgid "Calendar allocation"
+msgstr "Розподіл за календарем"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:30
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:35
+msgid "Assign quality form"
+msgstr "Призначити форму якості"
+
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:111
+msgid "No workers found"
+msgstr "Працівників не знайдено"
+
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:32
+msgid "Created By"
+msgstr "Створено"
+
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:22
+msgid "Profiles List"
+msgstr "Список профілів"
+
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:67
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:75
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:85
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:105
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:124
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:77
+msgid "Filter by labels"
+msgstr "Фільтрувати за мітками"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:259
+msgid "There are repeated material codes"
+msgstr "Є повторювані коди матеріалів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorization.java:43
+msgid "an authorization type must be set"
+msgstr "необхідно встановити тип авторизації"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:123
+msgid "Both"
+msgstr "Обидва"
+
+#: org/libreplan/web/orders/CriterionRequirementWrapper.java:46
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1091
+#: org/libreplan/web/workreports/WorkReportQueryController.java:259
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:82
+msgid "Direct"
+msgstr "Прямий"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskGroup.java:114
+msgid "element associated to a task group have to be defined"
+msgstr "елемент, пов'язаний з групою завдань, має бути визначений"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:254
+msgid "Inherited from parent calendar"
+msgstr "Успадковано від батьківського календаря"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:36
+msgid "Set Filter Options"
+msgstr "Встановити параметри фільтра"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:266
+msgid "Local document repository location"
+msgstr "Розташування локального сховища документів"
+
+#: org/libreplan/web/tree/TreeComponent.java:68
+msgid "Fully, Partially or Unscheduled. (Drag and drop to move tasks)"
+msgstr ""
+"Повністю, частково або не заплановано. (Перетягніть для переміщення завдань)"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:36
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:44
+msgid "General user data"
+msgstr "Загальні дані користувача"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:77
+msgid "Application URI"
+msgstr "URI застосунку"
+
+#: org/libreplan/web/common/CustomMenuController.java:570
+msgid "Personal area"
+msgstr "Особистий кабінет"
+
+#: org/libreplan/web/scenarios/ScenarioModel.java:131
+msgid "You cannot remove a scenario with derived scenarios"
+msgstr "Неможливо видалити сценарій з похідними сценаріями"
+
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:114
+msgid "Task of project"
+msgstr "Завдання проєкту"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:63
+msgid "Maximum/minimum of worked hours in finished applications"
+msgstr "Максимум/мінімум відпрацьованих годин у завершених заявках"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:13
+msgid "ON HOLD"
+msgstr "ПРИЗУПИНЕНО"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:207
+msgid "is not supported for its use with LibrePlan."
+msgstr "не підтримується для використання з LibrePlan."
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:397
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:438
+msgid "Edit Worker: {0}"
+msgstr "Редагувати працівника: {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:230
+msgid "external company should be subcontractor"
+msgstr "зовнішня компанія має бути субпідрядником"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:474
+msgid "seconds planning warning not specified"
+msgstr "секунди попередження планування не вказано"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:262
+msgid "Could have"
+msgstr "Бажано мати"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:107
+msgid ""
+"Estimated end date for the task (press enter in textbox to open calendar "
+"popup or type in date directly)"
+msgstr ""
+"Орієнтовна дата завершення завдання (натисніть Enter у текстовому полі, щоб "
+"відкрити спливний календар, або введіть дату безпосередньо)"
+
+#: org/libreplan/web/orders/DetailsOrderElementController.java:143
+msgid "must be after starting date"
+msgstr "має бути після дати початку"
+
+#: org/libreplan/web/common/ConfigurationController.java:265
+msgid "Scheduling or unscheduling of jobs for this connector is not completed"
+msgstr ""
+"Планування або скасування планування завдань для цього конектора не завершено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:406
+msgid "progress type should must be defined if quality form reports progress"
+msgstr "тип прогресу має бути визначений, якщо форма якості відстежує прогрес"
+
+#: org/libreplan/web/users/UserCRUDController.java:98
+#: org/libreplan/web/users/UserCRUDController.java:99
+#: org/libreplan/web/users/UserCRUDController.java:399
+msgid "No"
+msgstr "Ні"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:36
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:58
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:112
+msgid "Project Name"
+msgstr "Назва проєкту"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:455
+msgid "Extra"
+msgstr "Додатково"
+
+#: org/libreplan/web/planner/advances/AdvanceAssignmentPlanningCommand.java:69
+msgid "Progress assignment"
+msgstr "Призначення прогресу"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:51
+msgid "Sorry for the inconvenience."
+msgstr "Вибачте за незручності."
+
+#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:87
+msgid "Expense sheet \"{0}\" deleted"
+msgstr "Аркуш витрат \"{0}\" видалено"
+
+#: org/libreplan/web/common/ConfigurationController.java:484
+msgid "Failed to connect"
+msgstr "Не вдалося підключитися"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:436
+msgid "Authorization"
+msgstr "Авторизація"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:902
+msgid ""
+"Cannot delete timesheet template. There are some timesheets bound to it."
+msgstr "Неможливо видалити шаблон табелю. Деякі табелі прив'язані до нього."
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:41
+msgid "Your project could only partially be imported."
+msgstr "Ваш проєкт вдалося імпортувати лише частково."
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:284
+msgid "Stretch date must be earlier than End date: "
+msgstr "Дата розтягнення має бути раніше за дату завершення: "
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:50
+msgid "Selected node"
+msgstr "Вибраний вузол"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:39
+msgid "Template data"
+msgstr "Дані шаблону"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:228
+msgid "User already bound to other worker"
+msgstr "Користувач вже прив'язаний до іншого працівника"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:44
+#: libreplan-webapp/src/main/webapp/common/error.zul:49
+msgid "Status code"
+msgstr "Код статусу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:525
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderElementTemplate.java:379
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:108
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:158
+#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/Scenario.java:116
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Connector.java:70
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:97
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:204
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/Label.java:44
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:50
+msgid "name not specified"
+msgstr "назву не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:44
+msgid "Add From Template"
+msgstr "Додати з шаблону"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:248
+msgid "CV"
+msgstr "CV"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:979
+msgid "Worker deleted"
+msgstr "Працівника видалено"
+
+#: org/libreplan/web/orders/JiraSynchronizationController.java:278
+msgid "Start sync"
+msgstr "Почати синхронізацію"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:64
+msgid "Required materials"
+msgstr "Необхідні матеріали"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:307
+msgid "please select a user to bound"
+msgstr "будь ласка, виберіть користувача для прив'язки"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:110
+msgid "Has bound resource"
+msgstr "Має прив'язаний ресурс"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractorCommunication.java:80
+msgid "subcontracted task data not specified"
+msgstr "дані субпідрядного завдання не вказано"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:153
+msgid "No departments configured"
+msgstr "Відділи не налаштовано"
+
+#: org/libreplan/web/common/CustomMenuController.java:565
+msgid "Home"
+msgstr "Головна"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:34
+msgid "JIRA label"
+msgstr "Мітка JIRA"
+
+#: org/libreplan/web/workreports/WorkReportQueryController.java:261
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:83
+msgid "Indirect"
+msgstr "Непрямий"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:45
+msgid "Export to Tim"
+msgstr "Експорт до Tim"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1525
+msgid "must be before end date"
+msgstr "має бути до дати завершення"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:127
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:37
+#: libreplan-webapp/src/main/webapp/planner/main.zul:53
+msgid "Start"
+msgstr "Початок"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:79
+msgid "Page up"
+msgstr "Сторінка вгору"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:102
+msgid "Planning charts expanded"
+msgstr "Графіки планування розгорнуто"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:565
+#: org/libreplan/web/common/components/ResourceAllocationBehaviour.java:38
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:44
+msgid "Normal"
+msgstr "Звичайний"
+
+#: org/libreplan/web/orders/files/OrderFilesController.java:183
+msgid "Confirm deleting this file. Are you sure?"
+msgstr "Підтвердіть видалення цього файлу. Ви впевнені?"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:33
+msgid "Show resource assignments"
+msgstr "Показати призначення ресурсів"
+
+#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:323
+msgid "Total dedication"
+msgstr "Загальна віддача"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:875
+msgid "Hours cost: {0}, Expenses cost: {1}"
+msgstr "Вартість годин: {0}, Вартість витрат: {1}"
+
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:66
+msgid "Cannot calculate charts for current data"
+msgstr "Неможливо розрахувати графіки для поточних даних"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:22
+msgid "Quality Forms List"
+msgstr "Список форм якості"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:171
+msgid "please, select a quality form"
+msgstr "будь ласка, виберіть форму якості"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:479
+msgid "there are repeated description values in the timesheet lines"
+msgstr "є повторювані значення опису в рядках табелю"
+
+#: org/libreplan/web/tree/TreeController.java:1299
+msgid "Modified"
+msgstr "Змінено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:392
+msgid "You have exceeded the maximum limit of users"
+msgstr "Ви перевищили максимальний ліміт користувачів"
+
+#: org/libreplan/web/orders/TreeElementOperationsController.java:245
+msgid ""
+"Templates can only be created out of existent tasks.You are trying to create "
+"a template out of a new task.\n"
+"Please save your project before proceeding."
+msgstr ""
+"Шаблони можна створювати лише з існуючих завдань. Ви намагаєтесь створити "
+"шаблон з нового завдання.\n"
+"Будь ласка, збережіть проєкт перед продовженням."
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesCommand.java:60
+msgid "Task Properties"
+msgstr "Властивості завдання"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:203
+msgid "Unable to crate time registration for request"
+msgstr "Не вдалося створити реєстрацію часу для запиту"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:37
+msgid "ActionWhen"
+msgstr "ДіяКоли"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:309
+msgid "Create activation period"
+msgstr "Створити період активації"
+
+#: org/libreplan/web/common/TemplateModel.java:329
+msgid "Reassigning {0} projects"
+msgstr "Перепризначення {0} проєктів"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:254
+msgid "SPI"
+msgstr "SPI"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:223
+msgid "Origin"
+msgstr "Джерело"
+
+#: org/libreplan/web/importers/ProjectImportController.java:129
+msgid "Select one of the options."
+msgstr "Виберіть один з варіантів."
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1197
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1214
+msgid ""
+"Invalid value. Value must be greater than the value of previous progress."
+msgstr ""
+"Невірне значення. Значення має бути більше за значення попереднього прогресу."
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:143
+msgid "Check for updates"
+msgstr "Перевірити наявність оновлень"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:102
+msgid "Company logo URL"
+msgstr "URL логотипу компанії"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:972
+msgid "Do you want to remove bound user \"{0}\" too?"
+msgstr "Бажаєте також видалити прив'язаного користувача \"{0}\"?"
+
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:42
+msgid "Type and status"
+msgstr "Тип і статус"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:94
+msgid "Resources Per Day"
+msgstr "Ресурсів на день"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:64
+msgid "Log"
+msgstr "Журнал"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:249
+msgid "Schedule Variance"
+msgstr "Відхилення від розкладу"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:60
+msgid "Access to the system"
+msgstr "Доступ до системи"
+
+#: org/libreplan/web/planner/limiting/allocation/LimitingResourceAllocationModel.java:222
+msgid "All resources must be queue-based"
+msgstr "Усі ресурси мають бути на основі черги"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:35
+msgid "Configuration unit name"
+msgstr "Назва одиниці конфігурації"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:43
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:67
+msgid "Permissions"
+msgstr "Дозволи"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:703
+#: org/libreplan/web/orders/OrderModel.java:752
+#: org/libreplan/web/planner/TaskElementAdapter.java:846
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:66
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:50
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:62
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:68
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:50
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:40
+msgid "Progress"
+msgstr "Прогрес"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:21
+msgid "LibrePlan: Total Worked Hours By Resource In A Month"
+msgstr ""
+"LibrePlan: Загальна кількість відпрацьованих годин за ресурсом за місяць"
+
+#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:22
+msgid "LibrePlan: Progress Types"
+msgstr "LibrePlan: Типи прогресу"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:205
+msgid "cannot be empty or less than zero"
+msgstr "не може бути порожнім або менше нуля"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:70
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:36
+msgid "More options"
+msgstr "Більше параметрів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:295
+msgid "There are repeated description values in the timesheet "
+msgstr "Є повторювані значення опису в табелі "
+
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:194
+msgid "This resource has already been added."
+msgstr "Цей ресурс вже було додано."
+
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:71
+msgid "New password"
+msgstr "Новий пароль"
+
+#: org/libreplan/web/users/settings/PasswordController.java:101
+#: org/libreplan/web/users/UserCRUDController.java:286
+msgid "passwords don't match"
+msgstr "паролі не збігаються"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:170
+msgid "Add profile"
+msgstr "Додати профіль"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:15
+msgid "CANCELLED"
+msgstr "СКАСОВАНО"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:93
+msgid "Must start after"
+msgstr "Має починатися після"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:273
+msgid "Timesheet saved"
+msgstr "Табель збережено"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:105
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:168
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:165
+#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:47
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:98
+msgid "Save and Continue"
+msgstr "Зберегти та продовжити"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:168
+msgid "Criterion Requirements"
+msgstr "Вимоги до критеріїв"
+
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:525
+msgid "Cost Category"
+msgstr "Категорія витрат"
+
+#: org/libreplan/web/scenarios/TransferOrdersModel.java:170
+msgid "Project version is the same in source and destination scenarios"
+msgstr "Версія проєкту однакова у вихідному та цільовому сценаріях"
+
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:58
+msgid "Filter by task status"
+msgstr "Фільтрувати за статусом завдання"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/exceptionDays.zul:22
+msgid "LibrePlan: Calendar Exception Days"
+msgstr "LibrePlan: Виняткові дні календаря"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1081
+#: org/libreplan/web/resourceload/ResourceLoadController.java:1053
+msgid "The project has no scheduled elements"
+msgstr "Проєкт не має запланованих елементів"
+
+#: org/libreplan/web/common/CustomMenuController.java:538
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:39
+msgid "Project Costs"
+msgstr "Витрати проєкту"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:66
+msgid "Subcontract price"
+msgstr "Ціна субпідряду"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:108
+msgid "Sum of direct expenses"
+msgstr "Сума прямих витрат"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:40
+msgid "Uploaded by"
+msgstr "Завантажено"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:180
+msgid ""
+"Did you know LibrePlan is funded only by donations, from people like you?"
+msgstr ""
+"Чи знали ви, що LibrePlan фінансується лише за рахунок пожертв таких людей, "
+"як ви?"
+
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:29
+msgid "Issue number"
+msgstr "Номер питання"
+
+#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:699
+msgid "Start filtering date cannot be empty"
+msgstr "Початкова дата фільтрації не може бути порожньою"
+
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:280
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1107
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1339
+msgid "Please, select an item"
+msgstr "Будь ласка, виберіть елемент"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1368
+msgid "It cannot be empty"
+msgstr "Це поле не може бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:24
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:24
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:26
+msgid "Select required criteria set and press filter button"
+msgstr "Виберіть необхідний набір критеріїв і натисніть кнопку фільтра"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1028
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:96
+msgid "Function"
+msgstr "Функція"
+
+#: libreplan-webapp/src/main/webapp/scenarios/scenarios.zul:23
+msgid "LibrePlan: Scenarios Management"
+msgstr "LibrePlan: Керування сценаріями"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:22
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:26
+msgid "Print configuration"
+msgstr "Налаштування друку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1111
+msgid "dates must be sorted and cannot overlap"
+msgstr "дати мають бути впорядковані і не можуть перетинатися"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:23
+msgid "Criteria list"
+msgstr "Список критеріїв"
+
+#: org/libreplan/web/planner/limiting/allocation/LimitingResourceAllocationModel.java:153
+#: org/libreplan/web/planner/allocation/FormBinder.java:655
+msgid ""
+"there are no resources for required criteria: {0}. So the generic allocation "
+"can't be added"
+msgstr ""
+"немає ресурсів для необхідних критеріїв: {0}. Тому загальний розподіл не "
+"може бути додано"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1262
+msgid "Stretches list"
+msgstr "Список розтягнень"
+
+#: org/libreplan/web/labels/LabelTypeCRUDController.java:294
+msgid "Label Types"
+msgstr "Типи міток"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:437
+msgid "project calendar not specified"
+msgstr "календар проєкту не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:166
+msgid "Dependencies have priority"
+msgstr "Залежності мають пріоритет"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:26
+msgid "Profiles authorization"
+msgstr "Авторизація за профілями"
+
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:40
+msgid "Active period from"
+msgstr "Період активності з"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:140
+msgid "number of digits not specified"
+msgstr "кількість цифр не вказано"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:231
+msgid "Resource: {0}"
+msgstr "Ресурс: {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/HoursGroup.java:190
+msgid "working hours not specified"
+msgstr "робочі години не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:127
+msgid "unit name not specified"
+msgstr "назву одиниці не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:257
+msgid "delivery date not specified"
+msgstr "дату доставки не вказано"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:113
+msgid "Field"
+msgstr "Поле"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:714
+msgid ""
+"Advance assignment cannot be removed as it has advance measures that have "
+"already been reported to the customer"
+msgstr ""
+"Призначення прогресу не може бути видалено, оскільки воно має вимірювання "
+"прогресу, які вже були повідомлені замовнику"
+
+#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:105
+#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:137
+msgid "Projects List"
+msgstr "Список проєктів"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:138
+msgid "Exceptions"
+msgstr "Винятки"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:182
+msgid "Order-element for \"{0}\" issue not found"
+msgstr "Елемент проєкту для питання \"{0}\" не знайдено"
+
+#: org/libreplan/web/common/ConfigurationController.java:246
+msgid "Check all fields"
+msgstr "Перевірте всі поля"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:606
+msgid "Regular"
+msgstr "Звичайний"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:105
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:127
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:507
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:300
+msgid "JIRA connector not found"
+msgstr "Конектор JIRA не знайдено"
+
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:21
+msgid "LibrePlan: Estimated/Planned Hours Per Task"
+msgstr "LibrePlan: Орієнтовні/заплановані години за завданням"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:248
+msgid "Cost Variance"
+msgstr "Відхилення вартості"
+
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:76
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:60
+msgid "Split assignment"
+msgstr "Розділити призначення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:145
+msgid "number of digits out of range"
+msgstr "кількість цифр поза діапазоном"
+
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:211
+msgid "End date is not valid, the new end date must be after the start date"
+msgstr ""
+"Дата завершення недійсна, нова дата завершення має бути після дати початку"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:50
+msgid "Duration"
+msgstr "Тривалість"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:89
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:75
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:142
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:185
+msgid "E-mail"
+msgstr "Електронна пошта"
+
+#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:83
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:66
+msgid "Help"
+msgstr "Довідка"
+
+#: org/libreplan/web/common/CustomMenuController.java:550
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:39
+msgid "Materials Needed At Date"
+msgstr "Матеріали, необхідні на дату"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:319
+msgid "Delivery dates asked by the subcontractor. "
+msgstr "Дати доставки, запитані субпідрядником. "
+
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:107
+#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:113
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:117
+msgid "This project has already been added."
+msgstr "Цей проєкт вже було додано."
+
+#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/OrderVersion.java:55
+msgid "owner scenario not specified"
+msgstr "сценарій-власник не вказано"
+
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:162
+msgid "Output format:"
+msgstr "Формат виводу:"
+
+#: org/libreplan/web/orders/JiraSynchronizationController.java:175
+#: org/libreplan/web/orders/JiraSynchronizationController.java:222
+msgid "Failed: {0}"
+msgstr "Помилка: {0}"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:129
+msgid "Autocomplete login form"
+msgstr "Автозаповнення форми входу"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1659
+msgid "Configure"
+msgstr "Налаштувати"
+
+#: org/libreplan/web/common/components/finders/OrderBandboxFinder.java:44
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:51
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:63
+msgid "Project name"
+msgstr "Назва проєкту"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:147
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:43
+msgid "Show money cost bar"
+msgstr "Показати стовпчик грошових витрат"
+
+#: org/libreplan/web/tree/TreeComponent.java:58
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:902
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:36
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:64
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:89
+#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:29
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:61
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:83
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:55
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:339
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:58
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:41
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:56
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:39
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:33
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:39
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:37
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:37
+#: libreplan-webapp/src/main/webapp/templates/_advances.zul:39
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:51
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:41
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:285
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:31
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:37
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:41
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:37
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:68
+#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:28
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:57
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:64
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:80
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:52
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:32
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:311
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:30
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:154
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:31
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:87
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:40
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:95
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:36
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:52
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:144
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:170
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:28
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:28
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:81
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:57
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:185
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:31
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:37
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:40
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:58
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:42
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:39
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:41
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:70
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:131
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:48
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:26
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:29
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:123
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:89
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:131
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:97
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:138
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:110
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:154
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:97
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:138
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:180
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:103
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:150
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:193
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:101
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:101
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:144
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:115
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:132
+msgid "Operations"
+msgstr "Операції"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:96
+msgid "connector name not specified"
+msgstr "назву конектора не вказано"
+
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:21
+msgid "LibrePlan: Task Scheduling Status In Project"
+msgstr "LibrePlan: Статус планування завдань у проєкті"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:250
+msgid "Add Exception"
+msgstr "Додати виняток"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:507
+msgid "Deadline cannot be empty in backwards mode"
+msgstr "Кінцевий термін не може бути порожнім у зворотному режимі"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:449
+msgid "Group strategy"
+msgstr "Групова стратегія"
+
+#: org/libreplan/web/users/UserCRUDController.java:355
+msgid ""
+"User is bound to resource \"{0}\" and it will be unbound. Do you want to "
+"continue with user removal?"
+msgstr ""
+"Користувач прив'язаний до ресурсу \"{0}\" і буде відв'язаний. Бажаєте "
+"продовжити видалення користувача?"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:707
+msgid "task code is repeated inside the project"
+msgstr "код завдання повторюється всередині проєкту"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:264
+msgid "Save & New timesheet"
+msgstr "Зберегти і новий табель"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:541
+msgid "No JIRA issues found for key {0}"
+msgstr "Не знайдено питань JIRA для ключа {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/requirements/entities/CriterionRequirement.java:68
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:196
+msgid "criterion not specified"
+msgstr "критерій не вказано"
+
+#: org/libreplan/web/calendars/BaseCalendarModel.java:488
+#: org/libreplan/web/calendars/BaseCalendarModel.java:520
+msgid "This date cannot be empty"
+msgstr "Ця дата не може бути порожньою"
+
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:32
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:32
+msgid "Customer Reference"
+msgstr "Посилання замовника"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:27
+msgid "name"
+msgstr "назва"
+
+#: org/libreplan/web/common/ConfigurationModel.java:202
+msgid "At least one {0} sequence is needed"
+msgstr "Потрібна принаймні одна послідовність {0}"
+
+#: org/libreplan/web/common/CustomMenuController.java:295
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:48
+msgid "Projects"
+msgstr "Проєкти"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:126
+msgid "Total expenses"
+msgstr "Загальні витрати"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:292
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:308
+msgid "Prefix"
+msgstr "Префікс"
+
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:94
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:104
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:140
+#: libreplan-webapp/src/main/webapp/planner/main.zul:66
+#: libreplan-webapp/src/main/webapp/planner/reassign.zul:49
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:76
+#: libreplan-webapp/src/main/webapp/planner/order.zul:131
+#: libreplan-webapp/src/main/webapp/planner/order.zul:166
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:97
+msgid "Accept"
+msgstr "Прийняти"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:673
+msgid "Calculated progress can not be modified"
+msgstr "Розрахований прогрес не може бути змінений"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:81
+msgid "Timesheet summary"
+msgstr "Зведення табелю"
+
+#: org/libreplan/web/users/UserCRUDController.java:298
+msgid "Users"
+msgstr "Користувачі"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:110
+msgid "Availability"
+msgstr "Доступність"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:159
+msgid "Supported Chrome, Firefox, Safari and Epiphany browsers"
+msgstr "Підтримуються браузери Chrome, Firefox, Safari та Epiphany"
+
+#: org/libreplan/web/common/ConfigurationController.java:513
+#: org/libreplan/web/common/ConfigurationController.java:905
+#: org/libreplan/web/common/ConfigurationController.java:993
 msgid "number of digits must be between {0} and {1}"
+msgstr "кількість цифр має бути між {0} та {1}"
+
+#: org/libreplan/web/dashboard/DashboardController.java:274
+msgid " (%d tasks)"
+msgstr " (%d завдань)"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:204
+msgid "Exceptions list"
+msgstr "Список винятків"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:116
+msgid "Counter measures (CM)"
+msgstr "Контрзаходи (КЗ)"
+
+#: org/libreplan/web/orders/OrderElementController.java:133
+msgid "Edit task {0}"
+msgstr "Редагувати завдання {0}"
+
+#: libreplan-webapp/src/main/webapp/planner/index.zul:22
+msgid "LibrePlan: Planning"
+msgstr "LibrePlan: Планування"
+
+#: org/libreplan/web/common/BaseCRUDController.java:85
+msgid "{0} List"
+msgstr "Список {0}"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:162
+msgid "Budget hours"
+msgstr "Бюджетні години"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:145
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:64
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:31
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:45
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:28
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:33
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:69
+#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:25
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:50
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:53
+msgid "Starting date"
+msgstr "Дата початку"
+
+#: org/libreplan/web/common/components/finders/OrderElementInExpenseSheetBandboxFinder.java:45
+msgid "Task name (Task code)"
+msgstr "Назва завдання (Код завдання)"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:153
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:75
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:166
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:183
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:210
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:221
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:154
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:173
+msgid "Output format"
+msgstr "Формат виводу"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:26
+#: libreplan-webapp/src/main/webapp/common/error.zul:31
+msgid "Message - {0}"
+msgstr "Повідомлення - {0}"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:44
+msgid "Entity sequences"
+msgstr "Послідовності сутностей"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:39
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:39
+msgid "Total capability"
+msgstr "Загальна потужність"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/typeOfWorkHours.zul:23
+msgid "LibrePlan: Hours Types"
+msgstr "LibrePlan: Типи годин"
+
+#: org/libreplan/web/dashboard/DashboardController.java:266
+msgid ""
+"% Deviation interval (difference % between consumed and estimated hours)"
 msgstr ""
+"Інтервал відхилення % (різниця % між витраченими та орієнтовними годинами)"
+
+#: org/libreplan/web/scenarios/TransferOrdersController.java:190
+msgid "Project {0} transfered"
+msgstr "Проєкт {0} передано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:106
+msgid "Prefix cannot contain whitespaces"
+msgstr "Префікс не може містити пробіли"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:35
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:28
+msgid "Surname"
+msgstr "Прізвище"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:43
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:43
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:82
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:99
+msgid "Categories"
+msgstr "Категорії"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:192
+msgid "Material categories"
+msgstr "Категорії матеріалів"
+
+#: libreplan-webapp/src/main/webapp/myaccount/userDashboard.zul:21
+msgid "LibrePlan: My Dashboard"
+msgstr "LibrePlan: Моя панель"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:430
+msgid "Edit Virtual Workers Group: {0}"
+msgstr "Редагувати групу віртуальних працівників: {0}"
+
+#: org/libreplan/web/advance/AdvanceTypeModel.java:89
+msgid "Progress type cannot be modified"
+msgstr "Тип прогресу не може бути змінений"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:131
+msgid "No tasks available yet"
+msgstr "Завдання ще недоступні"
+
+#: org/libreplan/web/labels/LabelTypeCRUDController.java:289
+msgid "Label Type"
+msgstr "Тип мітки"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:413
+msgid "criterion names must be unique inside a criterion type"
+msgstr "назви критеріїв мають бути унікальними всередині типу критерію"
+
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:30
+msgid "Superuser"
+msgstr "Суперкористувач"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:90
+msgid "Total personal timesheet"
+msgstr "Загальний особистий табель"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:169
+msgid "host not specified"
+msgstr "хост не вказано"
+
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:21
+msgid "LibrePlan: Expenses"
+msgstr "LibrePlan: Витрати"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:109
+msgid "Hours Management"
+msgstr "Керування годинами"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1645
+msgid "Subcontracted by client"
+msgstr "Субпідряд від клієнта"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:433
+#: org/libreplan/web/logs/RiskLogCRUDController.java:413
+msgid "please select a project"
+msgstr "будь ласка, виберіть проєкт"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:29
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:58
+msgid "Subcontractor"
+msgstr "Субпідрядник"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/Material.java:105
+msgid "description is not specified"
+msgstr "опис не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:213
+msgid "WBS calculated budget"
+msgstr "Розрахований бюджет СРР"
+
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:34
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:29
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:27
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:44
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:59
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:61
+msgid "Status"
+msgstr "Статус"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:435
+msgid "Edit queue-based resource element"
+msgstr "Редагувати елемент ресурсу на основі черги"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:132
+msgid "Add task"
+msgstr "Додати завдання"
+
+#: org/libreplan/web/labels/LabelTypeModel.java:267
+msgid "Already exists other label with the same name"
+msgstr "Вже існує інша мітка з такою самою назвою"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:25
+msgid "Manual allocation"
+msgstr "Ручний розподіл"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:49
+msgid "Print"
+msgstr "Друк"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:85
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:122
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:32
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:31
+msgid "Unit price"
+msgstr "Ціна за одиницю"
+
+#: org/libreplan/web/common/components/finders/ResourceFilterEnum.java:29
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:221
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:45
+msgid "Cost category"
+msgstr "Категорія витрат"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:51
+msgid "Users authorization"
+msgstr "Авторизація користувачів"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:164
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:87
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:173
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:178
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:195
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:220
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:235
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:165
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:185
+msgid "Click on this"
+msgstr "Натисніть на це"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:148
+msgid "Resource / Criteria"
+msgstr "Ресурс / Критерії"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:157
+msgid "Year (optional)"
+msgstr "Рік (необов'язково)"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:33
+msgid "Overallocated"
+msgstr "Перевантажено"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:76
+msgid "Assignation"
+msgstr "Призначення"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:59
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:28
+msgid "Default price"
+msgstr "Ціна за замовчуванням"
+
+#: org/libreplan/web/common/CustomMenuController.java:431
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:75
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:47
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:60
+msgid "Cost"
+msgstr "Вартість"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:40
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:29
+msgid "Job name"
+msgstr "Назва завдання"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:391
+msgid "Removed calendar \"{0}\""
+msgstr "Видалено календар \"{0}\""
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:165
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:389
+msgid "report progress not specified"
+msgstr "звітування прогресу не вказано"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1634
+msgid "project code already being used"
+msgstr "код проєкту вже використовується"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:10
+msgid "OUTSOURCED"
+msgstr "НА АУТСОРСІ"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:306
+msgid "Entity type"
+msgstr "Тип сутності"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:245
+msgid "BCWS"
+msgstr "BCWS"
+
+#: org/libreplan/web/common/CustomMenuController.java:488
+msgid "Send To Customers"
+msgstr "Надіслати замовникам"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:73
+msgid "Files"
+msgstr "Файли"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:33
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:77
+msgid "Total work"
+msgstr "Загальна робота"
+
+#: org/libreplan/web/dashboard/DashboardController.java:248
+msgid "Estimation deviation on completed tasks"
+msgstr "Відхилення оцінки у завершених завданнях"
+
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:35
+msgid "Date Resolved"
+msgstr "Дата вирішення"
+
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:58
+msgid "Work done from starting date"
+msgstr "Виконана робота від дати початку"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:54
+msgid "Both calendars and gantt charts"
+msgstr "Календарі та діаграми Ганта"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:111
+msgid "Appropriative allocation"
+msgstr "Привласнювальний розподіл"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:150
+msgid ""
+"Help the project developers to collect information about which LibrePlan "
+"version you are using"
+msgstr ""
+"Допоможіть розробникам проєкту збирати інформацію про те, яку версію "
+"LibrePlan ви використовуєте"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:146
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:55
+msgid "Add role"
+msgstr "Додати роль"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:71
+msgid "Interacts with applications"
+msgstr "Взаємодіє із застосунками"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:150
+msgid "Go to personal timesheet"
+msgstr "Перейти до особистого табелю"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:318
+#: org/libreplan/web/scenarios/ScenarioCRUDController.java:129
+msgid "Create derived"
+msgstr "Створити похідний"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:138
+msgid "unl"
+msgstr "необм"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:31
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:96
+msgid "Date created"
+msgstr "Дата створення"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:162
+msgid "Scheduling mode"
+msgstr "Режим планування"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:161
+msgid "Alpha must be greater than 0"
+msgstr "Альфа має бути більше 0"
+
+#: org/libreplan/web/montecarlo/MonteCarloController.java:172
+msgid "Percentages should sum 100"
+msgstr "Відсотки мають становити в сумі 100"
+
+#: org/libreplan/web/common/TemplateController.java:245
+msgid ""
+" of LibrePlan is available. Please check next link for more information:"
+msgstr ""
+" LibrePlan доступна. Будь ласка, перейдіть за наступним посиланням для "
+"отримання додаткової інформації:"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Connector.java:101
+msgid "connector name is already being used"
+msgstr "назва конектора вже використовується"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:273
+msgid "calendar not specified"
+msgstr "календар не вказано"
+
+#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:722
+msgid "Start filtering date must be before than end filtering date"
+msgstr "Початкова дата фільтрації має бути раніше за кінцеву дату фільтрації"
+
+#: org/libreplan/web/common/CustomMenuController.java:302
+msgid "Resources Load"
+msgstr "Завантаження ресурсів"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:875
+msgid "Finish Hour"
+msgstr "Година завершення"
+
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:33
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:99
+msgid "Days from Beginning to Deadline"
+msgstr "Днів від початку до кінцевого терміну"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:665
+msgid "Inh"
+msgstr "Усп"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:92
+msgid "Price per hour"
+msgstr "Ціна за годину"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:62
+msgid "Company code"
+msgstr "Код компанії"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:39
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:26
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:34
+msgid "Cost category assignment"
+msgstr "Призначення категорії витрат"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:241
+msgid "Allocation: [{0},{1}]"
+msgstr "Розподіл: [{0},{1}]"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:145
+msgid "Percentage of estimated budget hours / hours consumed"
+msgstr "Відсоток орієнтовних бюджетних годин / витрачених годин"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:12
+msgid "STARTED"
+msgstr "РОЗПОЧАТО"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:52
+msgid "Select destination"
+msgstr "Виберіть призначення"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:50
+msgid "Multiple values per resource"
+msgstr "Кілька значень на ресурс"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1113
+msgid "You do not have permissions to go to edit user window"
+msgstr "У вас немає дозволу на перехід до вікна редагування користувача"
+
+#: org/libreplan/web/users/UserCRUDController.java:306
+msgid "Password cannot be empty"
+msgstr "Пароль не може бути порожнім"
+
+#: org/libreplan/web/labels/LabelTypeModel.java:278
+msgid "The name of the label is empty."
+msgstr "Назва мітки порожня."
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:11
+msgid "ACCEPTED"
+msgstr "ПРИЙНЯТО"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:25
+msgid "Current state indicators"
+msgstr "Індикатори поточного стану"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:282
+msgid "Customer reference"
+msgstr "Посилання замовника"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:477
+msgid "Role search query"
+msgstr "Запит пошуку ролей"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:495
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:578
+msgid ""
+"Cannot allocate selected element. There is not any queue that matches "
+"resource allocation criteria at any interval of time"
+msgstr ""
+"Неможливо розподілити вибраний елемент. Немає жодної черги, яка відповідає "
+"критеріям розподілу ресурсів у будь-якому інтервалі часу"
+
+#: org/libreplan/web/subcontract/FilterCommunicationEnum.java:28
+#: org/libreplan/web/workreports/WorkReportQueryController.java:252
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:852
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:186
+#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:212
+#: org/libreplan/web/resourceload/ResourceLoadController.java:727
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:80
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:81
+msgid "All"
+msgstr "Всі"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:449
+msgid "last task sequence code not specified"
+msgstr "останній код послідовності завдання не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:180
+msgid "base not specified"
+msgstr "базу не вказано"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:208
+msgid "Unlimited"
+msgstr "Необмежено"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:64
+msgid "Move selected task down"
+msgstr "Перемістити вибране завдання вниз"
+
+#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:171
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:352
+msgid "Start date cannot be empty"
+msgstr "Дата початку не може бути порожньою"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1232
+msgid "Budget-status"
+msgstr "Статус бюджету"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:380
+msgid "Calculate Number of Hours"
+msgstr "Розрахувати кількість годин"
+
+#: org/libreplan/web/orders/TreeElementOperationsController.java:239
+#: org/libreplan/web/users/UserCRUDController.java:421
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1103
+msgid "Unsaved changes will be lost. Would you like to continue?"
+msgstr "Незбережені зміни будуть втрачені. Бажаєте продовжити?"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeModel.java:330
+msgid "Already exists another criterion with the same name"
+msgstr "Вже існує інший критерій з такою самою назвою"
+
+#: org/libreplan/web/common/JobSchedulerController.java:213
+msgid "Completed"
+msgstr "Завершено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:72
+msgid "job name not specified"
+msgstr "назву завдання не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:26
+msgid ""
+"Synchronization order elements with JIRA issues was not completed for the "
+"following reasons:"
+msgstr ""
+"Синхронізацію елементів проєкту з питаннями JIRA не завершено з наступних "
+"причин:"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:100
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionValue.java:80
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:87
+msgid "value not specified"
+msgstr "значення не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:324
+msgid "A stretch has lower or equal values than the previous stretch"
+msgstr "Розтягнення має менші або рівні значення, ніж попереднє розтягнення"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:137
+msgid "User disabled"
+msgstr "Користувача деактивовано"
+
+#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:154
+msgid ""
+"Time period contains non valid data. Ending data must be older than starting "
+"date"
+msgstr ""
+"Часовий період містить недійсні дані. Дата завершення має бути пізніше за "
+"дату початку"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:25
+msgid "Imputed hours calculation"
+msgstr "Розрахунок зарахованих годин"
+
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:290
+msgid "Quality Form"
+msgstr "Форма якості"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:380
+msgid "Template cannot be removed because it has applications"
+msgstr "Шаблон не може бути видалений, оскільки він має застосунки"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:111
+msgid "Down"
+msgstr "Вниз"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:982
+msgid "This worker was already removed by other user"
+msgstr "Цього працівника вже було видалено іншим користувачем"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:294
+msgid "Delivery dates requested by customer. "
+msgstr "Дати доставки, запитані замовником. "
+
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:739
+msgid "Date must be inside visualization area"
+msgstr "Дата має бути в межах області візуалізації"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:50
+msgid "Cancel changes and back to scheduling"
+msgstr "Скасувати зміни та повернутися до планування"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:533
+msgid "Expense Sheet"
+msgstr "Аркуш витрат"
+
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:328
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:335
+msgid "Day is not valid"
+msgstr "День недійсний"
+
+#: org/libreplan/web/subcontract/ReportAdvancesController.java:198
+msgid "Progress sent successfully"
+msgstr "Прогрес успішно надіслано"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:26
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:62
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:50
+msgid "Probability"
+msgstr "Ймовірність"
+
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:299
+msgid "Virtual worker"
+msgstr "Віртуальний працівник"
+
+#: org/libreplan/web/users/settings/SettingsController.java:127
+msgid "Settings saved"
+msgstr "Налаштування збережено"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:472
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:285
+msgid "must be after the previous date"
+msgstr "має бути після попередньої дати"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:48
+msgid "Remaining time"
+msgstr "Час, що залишився"
+
+#: org/libreplan/web/planner/reassign/Type.java:55
+msgid "From chosen date"
+msgstr "З обраної дати"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:64
+msgid "Help on authentication (opens a new window)"
+msgstr "Довідка з автентифікації (відкривається в новому вікні)"
+
+#: libreplan-webapp/src/main/webapp/common/accessForbidden.zul:43
+msgid "Click the following link to return to home page: "
+msgstr "Натисніть на наступне посилання, щоб повернутися на головну сторінку: "
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/UnitType.java:76
+msgid "measure not specified"
+msgstr "вимірювання не вказано"
+
+#: org/libreplan/web/resources/worker/AssignedCriterionsModel.java:333
+#: org/libreplan/web/resources/machine/AssignedMachineCriterionsModel.java:398
+msgid ""
+"The {0} can not be assigned to this resource. Its interval overlaps with "
+"other criterion"
+msgstr ""
+"{0} не може бути призначено цьому ресурсу. Його інтервал перетинається з "
+"іншим критерієм"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:140
+msgid "Activation periods"
+msgstr "Періоди активації"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:47
+msgid "Load due to current project"
+msgstr "Завантаження через поточний проєкт"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:524
+msgid "No items found in 'OrderSyncInfo' to synchronize with JIRA issues"
+msgstr ""
+"Не знайдено елементів у 'OrderSyncInfo' для синхронізації з питаннями JIRA"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:234
+msgid "resource cannot be empty if it is shared by lines"
+msgstr "ресурс не може бути порожнім, якщо він спільний для рядків"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:70
+msgid "Filter by workers"
+msgstr "Фільтрувати за працівниками"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:472
+msgid "resource type does not allow enabled criteria"
+msgstr "тип ресурсу не дозволяє увімкнені критерії"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:76
+msgid "Exportation options"
+msgstr "Параметри експорту"
+
+#: org/libreplan/web/planner/order/SubcontractController.java:147
+msgid ""
+"It will only be possible to add a Deliver Date if all the deliver date "
+"exiting in the table have a CommunicationDate not empty. "
+msgstr ""
+"Дату доставки можна додати лише якщо всі існуючі дати доставки в таблиці "
+"мають непорожню дату повідомлення. "
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:109
+msgid "Day properties"
+msgstr "Властивості дня"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:593
+msgid "Label type already assigned"
+msgstr "Тип мітки вже призначено"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:50
+msgid "Value last progress measurement"
+msgstr "Значення останнього вимірювання прогресу"
+
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:35
+msgid "Total Budget"
+msgstr "Загальний бюджет"
+
+#: org/libreplan/web/users/dashboard/UserDashboardController.java:64
+msgid "Personal timesheet \"{0}\" saved"
+msgstr "Особистий табель \"{0}\" збережено"
+
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:273
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:75
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:34
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:61
+msgid "Customer"
+msgstr "Замовник"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:174
+msgid "Last stretch should have 100% for length and amount of work"
+msgstr "Останнє розтягнення має мати 100% для довжини та обсягу роботи"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:392
+msgid "Calculate Resources per Day"
+msgstr "Розрахувати ресурсів на день"
+
+#: org/libreplan/web/planner/taskedition/AdvancedAllocationTaskController.java:72
+msgid "Some allocations needed"
+msgstr "Потрібні деякі розподіли"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:498
+msgid "LibrePlan Role"
+msgstr "Роль LibrePlan"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:22
+msgid "JIRA sync information"
+msgstr "Інформація синхронізації JIRA"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:102
+msgid "cost assignment's start date not specified"
+msgstr "дату початку призначення витрат не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:24
+msgid "No projects"
+msgstr "Немає проєктів"
+
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:106
+msgid "you do not have permissions to create new labels"
+msgstr "у вас немає дозволу на створення нових міток"
+
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:102
+#: org/libreplan/web/reports/TimeLineRequiredMaterialController.java:107
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:113
+msgid "please, select a project"
+msgstr "будь ласка, виберіть проєкт"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:681
+#: org/libreplan/web/orders/OrderModel.java:761
+#: org/libreplan/web/templates/TemplatesTreeController.java:194
+#: org/libreplan/web/common/CustomMenuController.java:365
+#: org/libreplan/web/reports/ProjectStatusReportController.java:167
+#: org/libreplan/web/planner/TaskElementAdapter.java:883
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:53
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:64
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:69
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:51
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:170
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:81
+msgid "Labels"
+msgstr "Мітки"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:149
+msgid "type of work hours for personal timesheets cannot be disabled"
+msgstr "тип робочих годин для особистих табелів не може бути вимкнений"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:117
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:212
+msgid "Day"
+msgstr "День"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:58
+msgid "Spreading progress"
+msgstr "Розповсюдження прогресу"
+
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:549
+msgid "Machine was already removed"
+msgstr "Машину вже було видалено"
+
+#: libreplan-webapp/src/main/webapp/logs/_logs.zul:44
+msgid "Risk logs"
+msgstr "Журнали ризиків"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:37
+msgid "Resources capability"
+msgstr "Потужність ресурсів"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:33
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:58
+msgid "Authorize"
+msgstr "Авторизувати"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:538
+msgid "Expense Sheets"
+msgstr "Аркуші витрат"
+
+#: org/libreplan/web/tree/TreeComponent.java:172
+msgid "Delete task"
+msgstr "Видалити завдання"
+
+#: org/libreplan/web/common/CustomMenuController.java:444
+msgid "User Accounts"
+msgstr "Облікові записи користувачів"
+
+#: libreplan-webapp/src/main/webapp/common/concurrentModification.zul:33
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:56
+msgid "Continue"
+msgstr "Продовжити"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionValue.java:71
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:71
+msgid "field name not specified or empty"
+msgstr "назву поля не вказано або вона порожня"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:955
+msgid ""
+"This worker cannot be deleted because it has assignments to projects or "
+"imputed hours"
+msgstr ""
+"Цього працівника не можна видалити, оскільки він має призначення до проєктів "
+"або зараховані години"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:49
+msgid "Date last progress measurement"
+msgstr "Дата останнього вимірювання прогресу"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:368
+msgid "Calculate Workable Days"
+msgstr "Розрахувати робочі дні"
+
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:85
+msgid "Accumulated hours chart"
+msgstr "Графік накопичених годин"
+
+#: org/libreplan/web/planner/taskedition/EditTaskController.java:371
+msgid ""
+"The task has got progress consolidations. To change resource allocation type "
+"all consolidations must be removed before"
+msgstr ""
+"Завдання має консолідації прогресу. Щоб змінити тип розподілу ресурсів, "
+"спочатку необхідно видалити всі консолідації"
+
+#: org/libreplan/web/subcontract/FilterCommunicationEnum.java:29
+msgid "Not Reviewed"
+msgstr "Не перевірено"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:49
+#: libreplan-webapp/src/main/webapp/common/error.zul:54
+msgid "Stacktrace"
+msgstr "Трасування стеку"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:105
+msgid "Total capacity"
+msgstr "Загальна потужність"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:110
+msgid "user"
+msgstr "користувач"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:127
+msgid "worker's first name not specified"
+msgstr "ім'я працівника не вказано"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:90
+msgid "Company password"
+msgstr "Пароль компанії"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:137
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:52
+msgid "Association with roles"
+msgstr "Зв'язок з ролями"
+
+#: org/libreplan/web/montecarlo/MonteCarloController.java:144
+#: org/libreplan/web/montecarlo/MonteCarloController.java:273
+msgid "Number of iterations should be between 1 and {0}"
+msgstr "Кількість ітерацій має бути між 1 та {0}"
+
+#: org/libreplan/web/users/settings/PasswordController.java:112
+msgid "Current password is incorrect"
+msgstr "Поточний пароль невірний"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:86
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:69
+msgid "Creation info"
+msgstr "Інформація про створення"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:40
+msgid "Worked hours"
+msgstr "Відпрацьовані години"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:252
+msgid "Queue-based resources cannot be bound to any user"
+msgstr ""
+"Ресурси на основі черги не можуть бути прив'язані до жодного користувача"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:39
+msgid "Estimated hours"
+msgstr "Орієнтовні години"
+
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:181
+#: org/libreplan/web/planner/tabs/OrdersTabCreator.java:50
+msgid "Project Details"
+msgstr "Деталі проєкту"
+
+#: org/libreplan/web/users/dashboard/MyTasksAreaController.java:137
+msgid "Track time"
+msgstr "Відстежувати час"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:51
+msgid ""
+"Allow multiple values of this type of criterion in the same period of time"
+msgstr "Дозволити кілька значень цього типу критерію в одному періоді часу"
+
+#: org/libreplan/importers/OrderImporterMPXJ.java:608
+msgid "Linked calendar not found"
+msgstr "Пов'язаний календар не знайдено"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:31
+msgid "Transfer Projects Between Scenarios"
+msgstr "Передача проєктів між сценаріями"
+
+#: org/libreplan/web/resourceload/ResourceLoadController.java:457
+msgid "To"
+msgstr "До"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:492
+msgid "Starting date cannot be empty in forward mode"
+msgstr "Дата початку не може бути порожньою в прямому режимі"
+
+#: org/libreplan/web/planner/order/SubcontractController.java:270
+#: org/libreplan/web/planner/order/SubcontractController.java:273
+msgid "Update task end"
+msgstr "Оновити завершення завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1118
+msgid "code is already used in another project"
+msgstr "код вже використовується в іншому проєкті"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:43
+msgid ""
+"If you entered the URL directly in the navigation bar of the browser, please "
+"review it or click in the following link in order to go to initial page: "
+msgstr ""
+"Якщо ви ввели URL безпосередньо в адресний рядок браузера, перевірте його "
+"або натисніть на наступне посилання, щоб перейти на початкову сторінку: "
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:136
+msgid "worker's surname not specified"
+msgstr "прізвище працівника не вказано"
+
+#: org/libreplan/web/resourceload/ResourceLoadModel.java:984
+msgid "Specific Allocations"
+msgstr "Конкретні розподіли"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:80
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:36
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:57
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:86
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:75
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:532
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:144
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:179
+#: libreplan-webapp/src/main/webapp/planner/order.zul:104
+msgid "Value"
+msgstr "Значення"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:250
+msgid "Budget At Completion"
+msgstr "Бюджет на завершення"
+
+#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:153
+msgid ""
+"The planning of this task is not in the current scenenario.\n"
+"You should change to any of the following scenarios: {0}"
+msgstr ""
+"Планування цього завдання відсутнє в поточному сценарії.\n"
+"Вам слід перейти до одного з наступних сценаріїв: {0}"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:38
+msgid "Add criterion requirement"
+msgstr "Додати вимогу до критерію"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:66
+msgid "Labels without inheritance"
+msgstr "Мітки без успадкування"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:44
+msgid "Assigned load"
+msgstr "Призначене навантаження"
+
+#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementModel.java:187
+msgid "New hours group "
+msgstr "Нова група годин "
+
+#: org/libreplan/web/common/CustomMenuController.java:568
+msgid "Preferences"
+msgstr "Налаштування"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:126
+msgid "All changes will be lost. Are you sure?"
+msgstr "Всі зміни будуть втрачені. Ви впевнені?"
+
+#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:412
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:611
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:389
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:808
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:329
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1620
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:121
+#: org/libreplan/importers/notifications/ComposeMessage.java:194
+msgid "Error"
+msgstr "Помилка"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:366
+msgid "Base"
+msgstr "Базовий"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:458
+#: org/libreplan/web/common/BaseCRUDController.java:135
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1027
+msgid "Edit {0}: {1}"
+msgstr "Редагувати {0}: {1}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1437
+msgid "a quality form cannot be assigned twice to the same task"
+msgstr "форму якості не можна призначити двічі до одного і того ж завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConfigurationRolesLDAP.java:56
+msgid "LibrePlan role not specified"
+msgstr "Роль LibrePlan не вказана"
+
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:35
+msgid "Base calendar type"
+msgstr "Тип базового календаря"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:94
+msgid "Select scenario"
+msgstr "Вибрати сценарій"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:75
+msgid "Assignation type"
+msgstr "Тип призначення"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:35
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:128
+msgid "Contingency"
+msgstr "Непередбачені обставини"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1693
+msgid "It already exists a end date with the same date. "
+msgstr "Дата завершення з такою ж датою вже існує. "
+
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:126
+msgid "Disable Delete"
+msgstr "Вимкнути видалення"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:114
+msgid "Name of task"
+msgstr "Назва завдання"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:152
+msgid "Hours to allocate"
+msgstr "Годин для розподілу"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:250
+msgid "Customer information"
+msgstr "Інформація про замовника"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:115
+msgid "Total extra"
+msgstr "Загальна додаткова сума"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:78
+msgid "Node without children"
+msgstr "Вузол без дочірніх елементів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:260
+msgid "Virtual resources cannot be bound to any user"
+msgstr "Віртуальні ресурси не можуть бути прив'язані до жодного користувача"
+
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:62
+msgid "Normal resource allocation"
+msgstr "Звичайний розподіл ресурсів"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:260
+msgid "Must have"
+msgstr "Обов'язково"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:246
+msgid "Actual Cost Work Performed"
+msgstr "Фактична вартість виконаних робіт"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:121
+msgid "End date communicated by the subcontractor."
+msgstr "Дата завершення, повідомлена субпідрядником."
+
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:84
+#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:128
+#: org/libreplan/web/reports/ProjectStatusReportController.java:192
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:312
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:173
+#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:134
+#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:174
+msgid "please, select a label"
+msgstr "будь ласка, виберіть мітку"
+
+#: org/libreplan/web/materials/UnitTypeController.java:151
+msgid "The code is not valid. There is another unit type with the same code"
+msgstr "Код недійсний. Існує інший тип одиниці з таким самим кодом"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:110
+msgid "Total extra per day"
+msgstr "Загальна додаткова сума за день"
+
+#: org/libreplan/web/common/CustomMenuController.java:437
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:36
+msgid "Main Settings"
+msgstr "Основні налаштування"
+
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:21
+msgid "LibrePlan: Work And Progress Per Task"
+msgstr "LibrePlan: Робота та прогрес за завданням"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:251
+msgid "Estimate At Completion"
+msgstr "Прогноз на завершення"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:107
+msgid "Found resources"
+msgstr "Знайдені ресурси"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:155
+msgid "material category name has to be unique. It is already used"
+msgstr ""
+"Назва категорії матеріалу повинна бути унікальною. Вона вже використовується"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:404
+msgid "Authentication"
+msgstr "Автентифікація"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:152
+msgid "Change the password"
+msgstr "Змінити пароль"
+
+#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:42
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:165
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:79
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:202
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:146
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:67
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:72
+#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:39
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:104
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:134
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:112
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:262
+#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:37
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:114
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:193
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:221
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:100
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:92
+msgid "Save & Continue"
+msgstr "Зберегти та продовжити"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:634
+msgid "it must be greater than zero"
+msgstr "повинно бути більше нуля"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:304
+#: org/libreplan/web/common/CustomMenuController.java:323
+#: org/libreplan/web/common/CustomMenuController.java:588
+#: org/libreplan/web/importers/ProjectImportController.java:82
+#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:237
+msgid "Planning"
+msgstr "Планування"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:843
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:102
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:119
+#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:41
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:165
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:162
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:162
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:77
+#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:45
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:200
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:214
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:143
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:89
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:64
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:70
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:95
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:548
+#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:37
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:57
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:102
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:131
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:109
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:260
+#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:36
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:112
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:191
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:140
+#: libreplan-webapp/src/main/webapp/resources/worker/worker.zul:42
+#: libreplan-webapp/src/main/webapp/resources/worker/virtualWorkers.zul:40
+#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:45
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:97
+#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:45
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:90
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:48
+msgid "Save"
+msgstr "Зберегти"
+
+#: org/libreplan/web/orders/JiraSynchronizationController.java:283
+#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:126
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:1020
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:108
+#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:43
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:95
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:144
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:171
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:168
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:168
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:81
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:62
+#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:48
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:204
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:149
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:70
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:74
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:101
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:211
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:106
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:551
+#: libreplan-webapp/src/main/webapp/advance/advanceTypes.zul:38
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:143
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:106
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:137
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:115
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:266
+#: libreplan-webapp/src/main/webapp/workreports/workReportTypes.zul:38
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:116
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:195
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:143
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:103
+#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:46
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:94
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:49
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:50
+#: libreplan-webapp/src/main/webapp/planner/reassign.zul:50
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:78
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:48
+#: libreplan-webapp/src/main/webapp/planner/order.zul:134
+#: libreplan-webapp/src/main/webapp/planner/order.zul:170
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:99
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:481
+msgid "Progress cannot be consolidated."
+msgstr "Прогрес не може бути консолідований."
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:336
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:112
+msgid "Save date"
+msgstr "Зберегти дату"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:52
+msgid "task"
+msgstr "завдання"
+
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:30
+msgid "Inherits up to date"
+msgstr "Успадковує до дати"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:59
+msgid "If you want to see help/info page then"
+msgstr "Якщо ви хочете переглянути сторінку довідки/інформації, тоді"
+
+#: org/libreplan/web/users/UserCRUDController.java:495
+#: org/libreplan/web/users/UserCRUDController.java:503
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1139
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1147
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:609
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:617
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:40
+#: libreplan-webapp/src/main/webapp/unittypes/_listUnitTypes.zul:32
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:43
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:41
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:58
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:58
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:36
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:50
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:36
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:33
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:56
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:60
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:55
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:56
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:48
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:52
+msgid "Create"
+msgstr "Створити"
+
+#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:25
+msgid "is not completed for the following reasons:"
+msgstr "не завершено з наступних причин:"
+
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:33
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:102
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:114
+msgid "Bound resource"
+msgstr "Прив'язаний ресурс"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:121
+msgid "Risk Score After CM"
+msgstr "Оцінка ризику після КЗ"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:59
+msgid "By all tasks hours"
+msgstr "За годинами всіх завдань"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:54
+msgid "Apply changes and continue editing"
+msgstr "Застосувати зміни та продовжити редагування"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:85
+msgid "Our company username"
+msgstr "Ім'я користувача нашої компанії"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:32
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:62
+msgid "Color"
+msgstr "Колір"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:666
+msgid "resources per day cannot be empty or less than zero"
+msgstr "ресурсів на день не може бути порожнім або менше нуля"
+
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/Label.java:47
+msgid "type not specified"
+msgstr "тип не вказаний"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:249
+msgid "calculate based on task criteria and cost categories"
+msgstr "розрахувати на основі критеріїв завдання та категорій витрат"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:21
+msgid "LibrePlan: Import Project"
+msgstr "LibrePlan: Імпорт проєкту"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:22
+msgid "Companies List"
+msgstr "Список компаній"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:78
+msgid "Possible content keywords"
+msgstr "Можливі ключові слова вмісту"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:948
+msgid "Cannot be higher than finish hour"
+msgstr "Не може бути більше за годину завершення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1204
+msgid "last sequence code not specified"
+msgstr "останній код послідовності не вказано"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:48
+msgid "Non-assigned locations"
+msgstr "Непризначені місцезнаходження"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:459
+msgid "description value: the timesheet has not assigned the description field"
+msgstr "значення опису: у табелі не призначено поле опису"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:66
+msgid "Add materials"
+msgstr "Додати матеріали"
+
+#: org/libreplan/web/common/ConfigurationController.java:382
+msgid "Tim connection was successful"
+msgstr "З'єднання з Tim успішне"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:95
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:183
+msgid "start date not specified"
+msgstr "дата початку не вказана"
+
+#: org/libreplan/web/resources/criterion/CriterionsModel.java:216
+msgid "Resource type cannot be empty"
+msgstr "Тип ресурсу не може бути порожнім"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1010
+msgid "Task {0}"
+msgstr "Завдання {0}"
+
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:272
+msgid ""
+"Quality form should include an item with a value of 100% in order to report "
+"progress"
+msgstr ""
+"Форма якості повинна містити елемент зі значенням 100% для звітування про "
+"прогрес"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:424
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:72
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:35
+msgid "Capacity"
+msgstr "Потужність"
+
+#: org/libreplan/web/common/entrypoints/RedirectorSynthetiser.java:126
+msgid "Could not load any resource"
+msgstr "Не вдалося завантажити жоден ресурс"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:30
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:29
+msgid "with"
+msgstr "з"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:39
+#: libreplan-webapp/src/main/webapp/common/error.zul:44
+msgid "Exception type"
+msgstr "Тип винятку"
+
+#: org/libreplan/web/workreports/WorkReportQueryController.java:372
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:233
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:67
+msgid "Total hours"
+msgstr "Загальна кількість годин"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:50
+msgid "Estimations"
+msgstr "Оцінки"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:56
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:63
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:68
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:36
+msgid "First name"
+msgstr "Ім'я"
+
+#: org/libreplan/web/materials/MaterialsController.java:464
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:74
+msgid "List of materials for all categories (select one to filter)"
+msgstr "Список матеріалів для всіх категорій (виберіть одну для фільтрації)"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:611
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:32
+msgid "Personal timesheet"
+msgstr "Особистий табель"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:235
+msgid "Perspectives"
+msgstr "Перспективи"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:119
+msgid "cost assignment's category not specified"
+msgstr "категорія призначення витрат не вказана"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:115
+msgid "Project view"
+msgstr "Перегляд проєкту"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:290
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:139
+msgid "No worklog items found for \"{0}\" issue"
+msgstr "Записи роботи для задачі \"{0}\" не знайдено"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:21
+msgid "LibrePlan: User access"
+msgstr "LibrePlan: Доступ користувачів"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:303
+msgid "Expiry date"
+msgstr "Термін дії"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:263
+msgid "Won't have"
+msgstr "Не буде"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:235
+msgid "default maximum value of percentage progress type must be 100"
+msgstr ""
+"максимальне значення за замовчуванням для типу прогресу у відсотках повинно "
+"бути 100"
+
+#: org/libreplan/web/common/ConfigurationController.java:254
+msgid "Changes saved"
+msgstr "Зміни збережено"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:344
+msgid "Quality form cannot be removed as it is spreading progress"
+msgstr "Форму якості не можна видалити, оскільки вона поширює прогрес"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:814
+msgid "there are no valid periods for this calendar"
+msgstr "для цього календаря немає дійсних періодів"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:94
+msgid "First name of user"
+msgstr "Ім'я користувача"
+
+#: org/libreplan/web/common/CustomMenuController.java:390
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:84
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:221
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:181
+msgid "Resources"
+msgstr "Ресурси"
+
+#: org/libreplan/web/common/CustomMenuController.java:457
+msgid "Job Scheduling"
+msgstr "Планування завдань"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:87
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:123
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:33
+msgid "Category"
+msgstr "Категорія"
+
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:482
+msgid "There is not any assigned progress to current task"
+msgstr "Поточному завданню не призначено жодного прогресу"
+
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:240
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:257
+msgid "Project Scheduling"
+msgstr "Планування проєкту"
+
+#: org/libreplan/web/scenarios/ScenarioModel.java:117
+msgid "You cannot remove the default scenario \"{0}\""
+msgstr "Ви не можете видалити сценарій за замовчуванням \"{0}\""
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:275
+msgid "Bound user does not have the proper role"
+msgstr "Прив'язаний користувач не має відповідної ролі"
+
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:92
+msgid "Must start after (days since project start)"
+msgstr "Повинно починатися після (днів від початку проєкту)"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:142
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:54
+msgid "Length"
+msgstr "Довжина"
+
+#: org/libreplan/web/common/CustomMenuController.java:329
+msgid "Workers"
+msgstr "Працівники"
+
+#: org/libreplan/web/planner/company/CompanyPlanningModel.java:388
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:749
+msgid "date in the future"
+msgstr "дата в майбутньому"
+
+#: org/libreplan/web/planner/adaptplanning/AdaptPlanningCommand.java:70
+msgid "Adapting planning according to timesheets"
+msgstr "Адаптація планування відповідно до табелів"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:37
+msgid "Warning: Not editing from home page of bound users"
+msgstr ""
+"Попередження: Редагування не з домашньої сторінки прив'язаних користувачів"
+
+#: org/libreplan/web/resourceload/ResourceLoadModel.java:694
+msgid "Other projects"
+msgstr "Інші проєкти"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:77
+msgid "New quality form item"
+msgstr "Новий елемент форми якості"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:246
+msgid "ACWP"
+msgstr "ФВВР"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:468
+msgid "must be greater or equal than 0"
+msgstr "повинно бути більше або дорівнювати 0"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:439
+msgid "label type: the timesheet has not assigned this label type"
+msgstr "тип мітки: табелю не призначено цей тип мітки"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:210
+msgid "OK"
+msgstr "OK"
+
+#: org/libreplan/web/resources/criterion/CriterionsModel.java:179
+msgid "{0} not found type for criterion "
+msgstr "{0} не знайдено тип для критерію "
+
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:31
+msgid "MonteCarlo"
+msgstr "Монте-Карло"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:71
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:68
+msgid "Pagination"
+msgstr "Пагінація"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:252
+msgid "label type: the timesheet have not assigned this label type"
+msgstr "тип мітки: табелю не призначено цей тип мітки"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:372
+msgid "Calendar exception day not found"
+msgstr "День винятку календаря не знайдено"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:133
+msgid "Add New Complementary Field"
+msgstr "Додати нове додаткове поле"
+
+#: org/libreplan/web/common/components/finders/CriterionBandboxFinder.java:44
+msgid "Criterion Name"
+msgstr "Назва критерію"
+
+#: org/libreplan/web/subcontract/ReportAdvancesModel.java:223
+msgid "Problems connecting with client web service"
+msgstr "Проблеми з підключенням до клієнтського вебсервісу"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:268
+msgid "External code"
+msgstr "Зовнішній код"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:335
+msgid "Criterion has subelements"
+msgstr "Критерій має піделементи"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1067
+msgid "Removed {0}"
+msgstr "Видалено {0}"
+
+#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:165
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:348
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:208
+#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:172
+#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:211
+msgid "This Criterion has already been added."
+msgstr "Цей критерій вже було додано."
+
+#: org/libreplan/web/orders/OrderCRUDController.java:447
+msgid "Backwards"
+msgstr "Назад"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:362
+msgid ""
+"Last stretch should have one hundred percent length and one hundred percent "
+"of work percentage"
+msgstr ""
+"Останнє розтягнення повинно мати стовідсоткову довжину та стовідсотковий "
+"відсоток роботи"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1179
+msgid ""
+"Spread progress cannot be removed. Please select another progress as spread."
+msgstr ""
+"Поширюваний прогрес не можна видалити. Будь ласка, виберіть інший прогрес "
+"для поширення."
+
+#: org/libreplan/web/planner/taskedition/EditTaskController.java:164
+msgid "Edit task: {0}"
+msgstr "Редагувати завдання: {0}"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:25
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:25
+msgid "Projectname"
+msgstr "Назва проєкту"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:158
+msgid "Add New Label Type Field"
+msgstr "Додати нове поле типу мітки"
+
+#: org/libreplan/web/common/components/TwoWaySelector.java:79
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:585
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:593
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:601
+msgid "Unassigned"
+msgstr "Не призначено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:365
+msgid "the project must have a start date"
+msgstr "проєкт повинен мати дату початку"
+
+#: org/libreplan/web/common/CustomMenuController.java:425
+#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:111
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:188
+msgid "Hours Types"
+msgstr "Типи годин"
+
+#: org/libreplan/web/tree/TreeController.java:1143
+msgid "Value is not valid in current list of Hours Group"
+msgstr "Значення недійсне в поточному списку групи годин"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1114
+msgid "Sorry, you do not have permissions to access this project"
+msgstr "На жаль, у вас немає дозволів для доступу до цього проєкту"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:46
+#: libreplan-webapp/src/main/webapp/templates/_advances.zul:37
+msgid "Max value"
+msgstr "Максимальне значення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:85
+msgid "name not specified or empty"
+msgstr "назва не вказана або порожня"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:395
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:241
+msgid "budget not specified"
+msgstr "бюджет не вказано"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:40
+msgid "The page that you are requesting does not exist."
+msgstr "Сторінка, яку ви запитуєте, не існує."
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:250
+msgid "EAC"
+msgstr "ПНЗ"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:41
+msgid "Administration"
+msgstr "Адміністрування"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1051
+msgid "Some criterion satisfactions overlap in time"
+msgstr "Деякі задоволення критеріїв перетинаються в часі"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:307
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:47
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:47
+msgid "Active"
+msgstr "Активний"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:59
+msgid "Duration (days)"
+msgstr "Тривалість (дні)"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:216
+msgid "The quality form item positions must be unique and consecutive."
+msgstr ""
+"Позиції елементів форми якості повинні бути унікальними та послідовними."
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:261
+msgid "Should have"
+msgstr "Бажано"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:27
+msgid "Type name"
+msgstr "Назва типу"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:54
+msgid "Select template language"
+msgstr "Вибрати мову шаблону"
+
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:522
+msgid "Manual assignment"
+msgstr "Ручне призначення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityForm.java:112
+msgid "items cannot be checked until the previous items are checked before."
+msgstr ""
+"елементи не можна відмічати, поки попередні елементи не будуть відмічені."
+
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:32
+msgid "Stretches function configuration"
+msgstr "Конфігурація функції розтягнень"
+
+#: org/libreplan/web/users/OrderAuthorizationController.java:118
+msgid ""
+"Could not add those authorizations to profile {0} because they were already "
+"present."
+msgstr ""
+"Не вдалося додати ці авторизації до профілю {0}, оскільки вони вже присутні."
+
+#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:22
+msgid "Scenarios List"
+msgstr "Список сценаріїв"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:444
+msgid "Schedule from start to deadline"
+msgstr "Планувати від початку до кінцевого терміну"
+
+#: org/libreplan/web/common/CustomMenuController.java:290
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:112
+msgid "Company view"
+msgstr "Перегляд компанії"
+
+#: org/libreplan/web/planner/milestone/AddMilestoneCommand.java:54
+msgid "new milestone"
+msgstr "нова віха"
+
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:75
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:59
+msgid "Split"
+msgstr "Розділити"
+
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:160
+msgid "must be after end date"
+msgstr "повинно бути після дати завершення"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:697
+#: org/libreplan/web/common/CustomMenuController.java:357
+#: org/libreplan/web/reports/ProjectStatusReportController.java:179
+#: org/libreplan/web/resourceload/ResourceLoadController.java:553
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:166
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:36
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:40
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:32
+msgid "Criteria"
+msgstr "Критерії"
+
+#: org/libreplan/web/common/CustomMenuController.java:407
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:32
+msgid "Timesheet Lines List"
+msgstr "Список рядків табеля"
+
+#: libreplan-webapp/src/main/webapp/calendars/calendars.zul:22
+msgid "LibrePlan: Calendars"
+msgstr "LibrePlan: Календарі"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:661
+msgid "already exists an allocation for criteria {0}"
+msgstr "вже існує розподіл для критеріїв {0}"
+
+#: org/libreplan/web/materials/MaterialsController.java:461
+msgid "List of materials for category: {0}"
+msgstr "Список матеріалів для категорії: {0}"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:296
+msgid "Unindent"
+msgstr "Зменшити відступ"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:39
+msgid "material not specified"
+msgstr "матеріал не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/BaseCalendar.java:1209
+msgid "calendars with zero hours are not allowed"
+msgstr "календарі з нульовою кількістю годин не дозволені"
+
+#: libreplan-webapp/src/main/webapp/planner/reassign.zul:34
+msgid "Reassigning type"
+msgstr "Тип перепризначення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:137
+msgid "timesheet template not specified"
+msgstr "шаблон табеля не вказано"
+
+#: org/libreplan/web/resources/machine/MachineConfigurationController.java:148
+msgid "Criterion previously selected"
+msgstr "Критерій вже вибрано раніше"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:278
+msgid "High"
+msgstr "Високий"
+
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:21
+msgid "LibrePlan: Materials Needed At Date"
+msgstr "LibrePlan: Необхідні матеріали на дату"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:22
+msgid "Cost Categories List"
+msgstr "Список категорій витрат"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:278
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:302
+msgid "Valid from"
+msgstr "Дійсний з"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:146
+msgid "expense sheet not specified"
+msgstr "аркуш витрат не вказано"
+
+#: org/libreplan/web/orders/TimSynchronizationController.java:147
+msgid "Exporting timesheets to Tim failed. Check the Tim connector"
+msgstr "Експорт табелів до Tim не вдався. Перевірте конектор Tim"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:457
+msgid "criterion type does not allow hierarchy"
+msgstr "тип критерію не дозволяє ієрархію"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:87
+msgid "Hours groups"
+msgstr "Групи годин"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:45
+msgid "LDAP configuration"
+msgstr "Конфігурація LDAP"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:184
+msgid "without you, LibrePlan can’t exist."
+msgstr "без вас LibrePlan не може існувати."
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:293
+msgid "criterion name not specified"
+msgstr "назва критерію не вказана"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:239
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:357
+#: org/libreplan/importers/ExportTimesheetsToTim.java:291
+msgid "Worker \"{0}\" not found"
+msgstr "Працівника \"{0}\" не знайдено"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:60
+msgid "Create Virtual Worker"
+msgstr "Створити віртуального працівника"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:57
+#: libreplan-webapp/src/main/webapp/common/error.zul:61
+msgid "Reload"
+msgstr "Перезавантажити"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:53
+msgid "Edit selected task"
+msgstr "Редагувати вибране завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/VirtualWorker.java:98
+msgid "Virtual worker group name must be unique"
+msgstr "Назва групи віртуальних працівників повинна бути унікальною"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:14
+msgid "FINISHED"
+msgstr "ЗАВЕРШЕНО"
+
+#: org/libreplan/web/common/ConfigurationModel.java:206
+msgid "At least one {0} sequence must be active"
+msgstr "Принаймні одна послідовність {0} повинна бути активною"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:114
+msgid "Allowed values"
+msgstr "Допустимі значення"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1193
+msgid ""
+"Value must be a multiple of the precision value of the progress type: {0}"
+msgstr "Значення повинно бути кратним значенню точності типу прогресу: {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:248
+msgid ""
+"The quality item positions must be correct in function to the percentage."
+msgstr ""
+"Позиції елементів якості повинні бути правильними відповідно до відсотка."
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:192
+msgid "Heading Fields"
+msgstr "Поля заголовка"
+
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:73
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:30
+msgid "Assignment log"
+msgstr "Журнал призначень"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:121
+msgid "Go to edit worker window"
+msgstr "Перейти до вікна редагування працівника"
+
+#: org/libreplan/web/common/ConfigurationController.java:970
+msgid ""
+"Invalid format prefix. Format prefix cannot be empty, contain '_' or contain "
+"whitespaces."
+msgstr ""
+"Недійсний формат префіксу. Префікс формату не може бути порожнім, містити "
+"'_' або пробіли."
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConfigurationRolesLDAP.java:51
+msgid "role ldap not specified"
+msgstr "роль LDAP не вказана"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:283
+msgid "No worklogs found for \"{0}\" issue"
+msgstr "Записи роботи для задачі \"{0}\" не знайдено"
+
+#: org/libreplan/web/materials/UnitTypeController.java:131
+msgid ""
+"The meausure name is not valid. There is another unit type with the same "
+"measure name"
+msgstr ""
+"Назва одиниці виміру недійсна. Існує інший тип одиниці з такою ж назвою "
+"одиниці виміру"
+
+#: org/libreplan/web/planner/company/CompanyPlanningModel.java:348
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:705
+msgid "Earned value"
+msgstr "Освоєний обсяг"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:140
+msgid "values are not valid, the values must not be null"
+msgstr "значення недійсні, значення не повинні бути порожніми"
+
+#: org/libreplan/web/common/ConfigurationModel.java:211
+msgid "The {0} sequence prefixes cannot be repeated"
+msgstr "Префікси послідовності {0} не можуть повторюватися"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:99
+msgid "Last name of user"
+msgstr "Прізвище користувача"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:748
+msgid ""
+"Spread progress cannot be changed if there is a consolidation in any "
+"progress assignment"
+msgstr ""
+"Поширюваний прогрес не можна змінити, якщо є консолідація в будь-якому "
+"призначенні прогресу"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:238
+msgid "Timesheet removed successfully"
+msgstr "Табель успішно видалено"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:33
+msgid "Edit E-mail template"
+msgstr "Редагувати шаблон електронної пошти"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:50
+#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:41
+msgid "Save changes"
+msgstr "Зберегти зміни"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/externalcompanies.zul:23
+msgid "LibrePlan: Companies"
+msgstr "LibrePlan: Компанії"
+
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:31
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:93
+msgid "Authentication type"
+msgstr "Тип автентифікації"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:177
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:282
+msgid "%"
+msgstr "%"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:30
+msgid "Managing fields and labels"
+msgstr "Керування полями та мітками"
+
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:100
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:81
+#: libreplan-webapp/src/main/webapp/planner/order.zul:69
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:70
+msgid "Back"
+msgstr "Назад"
+
+#: org/libreplan/web/materials/MaterialsController.java:261
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:193
+#: org/libreplan/web/orders/OrderCRUDController.java:1018
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:399
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:233
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:954
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:212
+msgid "Confirm deleting {0}. Are you sure?"
+msgstr "Підтвердити видалення {0}. Ви впевнені?"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:48
+msgid "units not specified"
+msgstr "одиниці не вказано"
+
+#: org/libreplan/web/users/ProfileCRUDController.java:123
+msgid "Profile"
+msgstr "Профіль"
+
+#: org/libreplan/web/common/CustomMenuController.java:384
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:295
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:72
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:54
+msgid "Quality Forms"
+msgstr "Форми якості"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:160
+msgid "Start Date"
+msgstr "Дата початку"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1223
+msgid ""
+"Date is not valid, it must be later than the last progress consolidation"
+msgstr ""
+"Дата недійсна, вона повинна бути пізнішою за останню консолідацію прогресу"
 
 #: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:21
 msgid "LibrePlan: Hours Worked Per Resource"
-msgstr ""
+msgstr "LibrePlan: Відпрацьовані години за ресурсом"
 
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:642
-#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1278
-msgid "Exception end date should be greater or equals than start date"
-msgstr ""
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:367
+msgid "Amount work percentage should be between 0 and 100"
+msgstr "Відсоток обсягу роботи повинен бути від 0 до 100"
 
-#: libreplan-webapp/src/main/webapp/common/access_forbidden.zul:45
-#: libreplan-webapp/src/main/webapp/common/page_not_found.zul:45
+#: org/libreplan/web/common/ConfigurationController.java:1015
+msgid "Deleting sequence"
+msgstr "Видалення послідовності"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLabelTypeAssignment.java:41
+msgid "default label not specified"
+msgstr "мітка за замовчуванням не вказана"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:160
+msgid "Hours group"
+msgstr "Група годин"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:100
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:62
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:43
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:74
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:74
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:61
+msgid "Filter by projects"
+msgstr "Фільтрувати за проєктами"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1080
+msgid "Some cost category assignments overlap in time"
+msgstr "Деякі призначення категорій витрат перетинаються в часі"
+
+#: libreplan-webapp/src/main/webapp/planner/fileupload.zul:51
+msgid "Please select a file on your system"
+msgstr "Будь ласка, виберіть файл на вашому комп'ютері"
+
+#: org/libreplan/web/orders/ProjectDetailsController.java:299
+msgid "Set Code as autogenerated to create a new project from templates"
+msgstr ""
+"Встановіть код як автоматично згенерований для створення нового проєкту з "
+"шаблонів"
+
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:62
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:26
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:71
+msgid "Task quality forms"
+msgstr "Форми якості завдання"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:183
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:120
+msgid "Existing user"
+msgstr "Існуючий користувач"
+
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:48
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:44
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:76
+msgid "Template"
+msgstr "Шаблон"
+
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:201
+msgid "last label sequence code not specified"
+msgstr "останній код послідовності мітки не вказано"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:35
+msgid "Planned end"
+msgstr "Плановане завершення"
+
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:65
+msgid "Current password"
+msgstr "Поточний пароль"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:311
+msgid "from {0}"
+msgstr "з {0}"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:39
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:29
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:60
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:88
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:51
+msgid "Filter"
+msgstr "Фільтр"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:193
+msgid "Resources load since"
+msgstr "Завантаження ресурсів з"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:450
+msgid "Property strategy"
+msgstr "Стратегія властивості"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:36
+#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:30
+msgid "Select parent calendar"
+msgstr "Вибрати батьківський календар"
+
+#: org/libreplan/web/scenarios/ScenarioCRUDController.java:171
+msgid "Connect"
+msgstr "З'єднати"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:356
+msgid "Exception name should not be empty"
+msgstr "Назва винятку не повинна бути порожньою"
+
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:307
+msgid "Hours type should not be empty to synchronine timesheets"
+msgstr "Тип годин не повинен бути порожнім для синхронізації табелів"
+
+#: org/libreplan/web/users/UserCRUDController.java:435
+msgid "You do not have permissions to go to edit worker window"
+msgstr "У вас немає дозволів для переходу до вікна редагування працівника"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:33
+msgid "Import Project"
+msgstr "Імпорт проєкту"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:247
+msgid "Budgeted Cost Work Performed"
+msgstr "Бюджетна вартість виконаних робіт"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:138
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:93
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:39
+msgid "Show progress"
+msgstr "Показати прогрес"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:49
+msgid "Current value"
+msgstr "Поточне значення"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:25
+msgid "My tasks"
+msgstr "Мої завдання"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:299
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:314
+msgid "Not indentable"
+msgstr "Не можна збільшити відступ"
+
+#: libreplan-webapp/src/main/webapp/resourceload/resourceload.zul:22
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:22
+#: libreplan-webapp/src/main/webapp/planner/main.zul:22
+#: libreplan-webapp/src/main/webapp/planner/order.zul:22
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:22
+#: libreplan-webapp/src/main/webapp/planner/resources_use.zul:22
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:22
+msgid "LibrePlan: Scheduling"
+msgstr "LibrePlan: Планування"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:274
+msgid "Parent"
+msgstr "Батьківський"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:75
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:77
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:180
+msgid "Password confirmation"
+msgstr "Підтвердження пароля"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:50
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:28
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:47
+msgid "Criterion name"
+msgstr "Назва критерію"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:447
+msgid "Effort must be greater than zero"
+msgstr "Трудовитрати повинні бути більше нуля"
+
+#: org/libreplan/web/users/UserCRUDController.java:293
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:90
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:63
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:134
+msgid "User"
+msgstr "Користувач"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1027
+#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:144
+msgid "Not enough permissions to edit this project"
+msgstr "Недостатньо дозволів для редагування цього проєкту"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:548
+#: org/libreplan/web/orders/OrderCRUDController.java:1424
+#: org/libreplan/web/orders/ProjectDetailsController.java:253
+#: org/libreplan/web/orders/OrderElementTreeController.java:764
+#: org/libreplan/web/workreports/WorkReportQueryController.java:155
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:794
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:423
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:146
+#: org/libreplan/web/planner/company/CompanyPlanningController.java:309
+#: org/libreplan/web/planner/order/OrderPlanningController.java:361
+msgid "must be lower than end date"
+msgstr "повинно бути менше за дату завершення"
+
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:23
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:259
+msgid "Create new Workweek"
+msgstr "Створити новий робочий тиждень"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:177
+msgid "Hours Group"
+msgstr "Група годин"
+
+#: org/libreplan/web/common/CustomMenuController.java:498
+msgid "Communications"
+msgstr "Комунікації"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:704
+msgid "The field name must be unique and not empty"
+msgstr "Назва поля повинна бути унікальною та не порожньою"
+
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:36
+msgid "Show only current satisfied criteria"
+msgstr "Показувати тільки поточні задоволені критерії"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1012
+msgid "Virtual Workers Group"
+msgstr "Група віртуальних працівників"
+
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:165
+msgid "Company ID already used. It must be unique"
+msgstr ""
+"Ідентифікатор компанії вже використовується. Він повинен бути унікальним"
+
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:76
+msgid "Show dependencies"
+msgstr "Показати залежності"
+
+#: org/libreplan/web/resources/criterion/CriterionAdminController.java:97
+msgid "Question"
+msgstr "Питання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:295
+msgid "last material sequence code not specified"
+msgstr "останній код послідовності матеріалу не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:331
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:180
+msgid "last hours group sequence code not specified"
+msgstr "останній код послідовності групи годин не вказано"
+
+#: org/libreplan/web/common/CustomMenuController.java:543
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:39
+msgid "Task Scheduling Status In Project"
+msgstr "Статус планування завдань у проєкті"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:149
+msgid "Worker ID cannot be empty"
+msgstr "Ідентифікатор працівника не може бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:39
+msgid "Predecessor"
+msgstr "Попередник"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:88
+msgid "Change scenario"
+msgstr "Змінити сценарій"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:115
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:116
+msgid "the expense sheet must have least a expense sheet line."
+msgstr "аркуш витрат повинен мати принаймні один рядок аркуша витрат."
+
+#: org/libreplan/web/common/JobSchedulerController.java:403
+msgid "Job is deleted from scheduler"
+msgstr "Завдання видалено з планувальника"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:506
+msgid "resource has to be bound to a user in personal timesheets"
+msgstr "ресурс повинен бути прив'язаний до користувача в особистих табелях"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:96
+msgid "Number of iterations"
+msgstr "Кількість ітерацій"
+
+#: org/libreplan/web/resources/worker/AssignedCriterionsModel.java:338
+#: org/libreplan/web/resources/machine/AssignedMachineCriterionsModel.java:401
+msgid "The {0} is not valid. Other value exists from the same criterion type"
+msgstr "{0} недійсний. Існує інше значення того ж типу критерію"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:180
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:214
+msgid "Exception Type"
+msgstr "Тип винятку"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:126
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:138
+msgid "Total hours task"
+msgstr "Загальна кількість годин завдання"
+
+#: org/libreplan/web/orders/OrderModel.java:756
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:84
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:116
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:44
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:61
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:30
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:28
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:111
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:94
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:35
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:105
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:35
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:32
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:43
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:49
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:39
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:55
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:89
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:83
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:36
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:62
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:67
+msgid "Description"
+msgstr "Опис"
+
+#: org/libreplan/web/users/settings/PasswordController.java:73
+msgid "Password saved"
+msgstr "Пароль збережено"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:197
+msgid "Update exception"
+msgstr "Оновити виняток"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:478
+#: org/libreplan/web/resources/worker/CriterionsController.java:93
+msgid "MessagesContainer is needed"
+msgstr "Потрібен MessagesContainer"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:178
+msgid "The field name must be unique."
+msgstr "Назва поля повинна бути унікальною."
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:266
+msgid "percentages in quality form items must be unique"
+msgstr "відсотки в елементах форми якості повинні бути унікальними"
+
+#: org/libreplan/web/resources/criterion/CriterionAdminController.java:112
+msgid "Tree {0} sucessfully flattened"
+msgstr "Дерево {0} успішно вирівняно"
+
+#: org/libreplan/web/importers/ProjectImportController.java:107
+#: org/libreplan/web/importers/ProjectImportController.java:123
+msgid "Instance not found."
+msgstr "Екземпляр не знайдено."
+
+#: org/libreplan/web/common/IntegrationEntityModel.java:79
+msgid "Could not retrieve Code. Please, try again later"
+msgstr "Не вдалося отримати код. Будь ласка, спробуйте пізніше"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:133
+msgid "Assignments could not be completed"
+msgstr "Не вдалося завершити призначення"
+
+#: org/libreplan/web/workreports/WorkReportTypeModel.java:414
+msgid "There is another timesheet template with the same name"
+msgstr "Існує інший шаблон табеля з такою ж назвою"
+
+#: org/libreplan/web/common/components/ResourceAllocationBehaviour.java:63
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:39
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:38
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:94
+msgid "Queue-based"
+msgstr "На основі черги"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:151
+msgid ""
+"Check this option if you would like to send feedback to LibrePlan developers "
+"about program usage"
+msgstr ""
+"Відмітьте цю опцію, якщо ви хочете надсилати зворотний зв'язок розробникам "
+"LibrePlan про використання програми"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:40
+msgid "Human hours per machine working hour within configuration unit"
+msgstr "Людино-години на машино-годину роботи в межах конфігураційної одиниці"
+
+#: org/libreplan/web/orders/files/OrderFilesController.java:283
+msgid "Please, make repository"
+msgstr "Будь ласка, створіть репозиторій"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:347
+msgid "Project saved"
+msgstr "Проєкт збережено"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:997
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:563
+msgid "no"
+msgstr "ні"
+
+#: org/libreplan/web/templates/OrderTemplatesModel.java:304
+msgid "Already exists another template with the same name"
+msgstr "Вже існує інший шаблон з такою ж назвою"
+
+#: org/libreplan/web/common/JobSchedulerController.java:328
+msgid "Unable to parse cron expression"
+msgstr "Не вдалося розібрати cron-вираз"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:424
+msgid "Save passwords in database"
+msgstr "Зберігати паролі в базі даних"
+
+#: org/libreplan/web/scenarios/ScenarioCRUDController.java:227
+msgid "Scenario"
+msgstr "Сценарій"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:294
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:309
+msgid "Number of digits"
+msgstr "Кількість цифр"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:47
+msgid "Estimated hours average"
+msgstr "Середня оцінка годин"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:608
+#: libreplan-webapp/src/main/webapp/myaccount/userDashboard.zul:35
+msgid "My dashboard"
+msgstr "Моя панель"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:844
+msgid "Resources per day are zero"
+msgstr "Ресурсів на день — нуль"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:698
+msgid "Edit Timesheet"
+msgstr "Редагувати табель"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:24
+#: libreplan-webapp/src/main/webapp/templates/_advances.zul:27
+msgid "Progress assignments"
+msgstr "Призначення прогресу"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:396
+msgid "Workable capacity for this period "
+msgstr "Робоча потужність за цей період "
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:213
+msgid "timesheet not specified"
+msgstr "табель не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceAssignment.java:76
+msgid "progress type not specified"
+msgstr "тип прогресу не вказано"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:3
+msgid "Show archived column data"
+msgstr "Показати дані архівного стовпця"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1175
+msgid "You have exceeded the maximum limit of resources"
+msgstr "Ви перевищили максимальний ліміт ресурсів"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:378
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:1027
+msgid "Confirm exit dialog"
+msgstr "Діалог підтвердження виходу"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:215
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:283
+#: org/libreplan/web/common/EffortDurationBox.java:49
+msgid "Invalid Effort Duration"
+msgstr "Недійсна тривалість трудовитрат"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:143
+msgid "Incorrect authentication"
+msgstr "Невірна автентифікація"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:359
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:84
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:143
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:168
+msgid "Position"
+msgstr "Позиція"
+
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:33
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:32
+msgid "Total price"
+msgstr "Загальна ціна"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:112
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:36
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:149
+msgid "Responsible"
+msgstr "Відповідальний"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:120
+msgid "Select gap"
+msgstr "Вибрати проміжок"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:45
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:176
+msgid "Exclude finished projects"
+msgstr "Виключити завершені проєкти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/Profile.java:89
+msgid "profile name is already being used by another profile"
+msgstr "назва профілю вже використовується іншим профілем"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:22
+msgid "LibrePlan: Page not found"
+msgstr "LibrePlan: Сторінку не знайдено"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:28
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:53
+msgid "Client"
+msgstr "Клієнт"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:63
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:78
+msgid "Reviewed"
+msgstr "Перевірено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:81
+msgid "quality form item position not specified"
+msgstr "позиція елемента форми якості не вказана"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:252
+msgid "Hours cost"
+msgstr "Вартість годин"
+
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:25
+msgid "No criterions"
+msgstr "Немає критеріїв"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:20
+msgid "LibrePlan: Received From Subcontractors"
+msgstr "LibrePlan: Отримано від субпідрядників"
+
+#: org/libreplan/web/orders/DynamicDatebox.java:152
+msgid "Date format is wrong. Please, use the following format: {0}"
+msgstr "Формат дати невірний. Будь ласка, використовуйте наступний формат: {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:589
+msgid "project name is already being used"
+msgstr "назва проєкту вже використовується"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:53
+msgid "Gantt charts"
+msgstr "Діаграми Ганта"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:486
+msgid "cannot be empty."
+msgstr "не може бути порожнім."
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:37
+msgid "Work record"
+msgstr "Запис роботи"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:33
+msgid "Communications From Customers"
+msgstr "Комунікації від замовників"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:69
+msgid "Total task hours"
+msgstr "Загальна кількість годин завдання"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:43
+msgid "Filter by month"
+msgstr "Фільтрувати за місяцем"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/DirectAdvanceAssignment.java:82
+msgid "maximum value not specified"
+msgstr "максимальне значення не вказано"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:91
+msgid "Group by weeks"
+msgstr "Групувати за тижнями"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:414
+msgid "The timesheet line codes must be unique."
+msgstr "Коди рядків табеля повинні бути унікальними."
+
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:22
+msgid "Projects list"
+msgstr "Список проєктів"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:337
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:37
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:94
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:63
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:41
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:69
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:60
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:57
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:130
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:47
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:63
+msgid "End date"
+msgstr "Дата завершення"
+
+#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:106
+msgid "Hours Type"
+msgstr "Тип годин"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLabelTypeAssignment.java:38
+msgid "label type not specified"
+msgstr "тип мітки не вказано"
+
+#: org/libreplan/web/common/TemplateModel.java:333
+msgid "{0} projects remaining to reassign"
+msgstr "{0} проєктів залишилося для перепризначення"
+
+#: org/libreplan/web/common/ConfigurationController.java:465
+msgid "Connection successful!"
+msgstr "З'єднання успішне!"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:350
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:361
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:371
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:381
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:419
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:461
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:472
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:482
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:81
+msgid "Example: {0}"
+msgstr "Приклад: {0}"
+
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:21
+msgid "Templates List"
+msgstr "Список шаблонів"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:108
+msgid ""
+"Load percentage of resources participating in the project while they are "
+"assigned"
+msgstr ""
+"Відсоток завантаження ресурсів, що беруть участь у проєкті, поки вони "
+"призначені"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:129
+msgid "{0} reassignations finished"
+msgstr "{0} перепризначень завершено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialInfo.java:61
+msgid "unit price not specified"
+msgstr "ціна за одиницю не вказана"
+
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:144
+msgid "Action When"
+msgstr "Дія при"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLineGroup.java:1116
+msgid "indirect progress assignments should have different types"
+msgstr "непрямі призначення прогресу повинні мати різні типи"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1687
+msgid ""
+"It will only be possible to add an end date if all the exiting ones in the "
+"table have already been sent to the customer."
+msgstr ""
+"Додати дату завершення можна лише тоді, коли всі існуючі дати в таблиці вже "
+"надіслані замовнику."
+
+#: org/libreplan/web/subcontract/ReportAdvancesModel.java:225
+#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:240
+#: org/libreplan/web/subcontract/SubcontractedTasksModel.java:277
+msgid "Error: {0}"
+msgstr "Помилка: {0}"
+
+#: org/libreplan/web/users/UserCRUDController.java:357
+msgid "Confirm remove user"
+msgstr "Підтвердити видалення користувача"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:129
+msgid "Create New Project"
+msgstr "Створити новий проєкт"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:101
+msgid "Available materials"
+msgstr "Доступні матеріали"
+
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:69
+msgid "New label"
+msgstr "Нова мітка"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:108
+msgid "Cron expression format"
+msgstr "Формат cron-виразу"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:960
+msgid "Confirm deleting this worker. Are you sure?"
+msgstr "Підтвердити видалення цього працівника. Ви впевнені?"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:66
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:29
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:28
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:29
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:67
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:61
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:28
+msgid "Enabled"
+msgstr "Увімкнено"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:60
+msgid "Project closing previsions"
+msgstr "Прогнози закриття проєкту"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1511
+msgid "must be later than start date"
+msgstr "повинно бути пізніше за дату початку"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:446
+msgid "Only {0} resources per day were achieved for current allocation"
+msgstr "Для поточного розподілу досягнуто лише {0} ресурсів на день"
+
+#: org/libreplan/web/common/ConfigurationController.java:410
+msgid "JIRA connection was successful"
+msgstr "З'єднання з JIRA успішне"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1213
+msgid "Hours-status"
+msgstr "Години-статус"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:80
+msgid ""
+"Invalid value. Precission value must be lower than the Default Max value."
+msgstr ""
+"Недійсне значення. Значення точності повинно бути менше за максимальне "
+"значення за замовчуванням."
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1057
+#: org/libreplan/web/templates/OrderTemplatesController.java:369
+#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:81
+#: org/libreplan/web/common/BaseCRUDController.java:307
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:155
+msgid "Confirm"
+msgstr "Підтвердити"
+
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:120
+msgid "Apply filter to"
+msgstr "Застосувати фільтр до"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:383
+msgid "At least one hours group is needed for each task"
+msgstr "Для кожного завдання потрібна принаймні одна група годин"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:169
+msgid "Dedication"
+msgstr "Виділення"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionController.java:127
+msgid "Confirm cancel"
+msgstr "Підтвердити скасування"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:455
+msgid ""
+"Value is not valid.\n"
+" Code cannot contain chars like '_' \n"
+" and should not be empty"
+msgstr ""
+"Значення недійсне.\n"
+" Код не може містити символи '_' \n"
+" і не повинен бути порожнім"
+
+#: org/libreplan/web/common/components/NewAllocationSelector.java:55
+msgid "generic workers allocation"
+msgstr "загальний розподіл працівників"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:892
+msgid "Task finished"
+msgstr "Завдання завершено"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:410
+msgid "issuelog-number"
+msgstr "issuelog-number"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1640
+msgid "Please select a worker"
+msgstr "Будь ласка, виберіть працівника"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:139
+msgid "The expense sheet line codes must be unique."
+msgstr "Коди рядків аркуша витрат повинні бути унікальними."
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1371
+msgid "See scheduling"
+msgstr "Переглянути планування"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:540
+msgid "Test connection"
+msgstr "Перевірити з'єднання"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:174
+msgid "here"
+msgstr "тут"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:75
+msgid "Resource allocation type"
+msgstr "Тип розподілу ресурсів"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:260
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:677
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1110
+msgid ""
+"Subcontractor values are read only because they were reported by the "
+"subcontractor company."
+msgstr ""
+"Значення субпідрядника доступні лише для читання, оскільки вони були надані "
+"субпідрядною компанією."
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:22
+msgid "Machines List"
+msgstr "Список машин"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:442
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:155
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:82
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:118
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:203
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:38
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:32
+#: libreplan-webapp/src/main/webapp/planner/order.zul:154
+msgid "Calendar"
+msgstr "Календар"
+
+#: org/libreplan/web/common/components/finders/OrderBandboxFinder.java:44
+#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:35
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:50
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:44
+msgid "Project code"
+msgstr "Код проєкту"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:165
+msgid ""
+"Profiles of LDAP users cannot be managed because LDAP is enabled and LDAP "
+"roles are being used."
+msgstr ""
+"Профілями користувачів LDAP неможливо керувати, оскільки LDAP увімкнено та "
+"використовуються ролі LDAP."
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:171
+msgid "Hours margin"
+msgstr "Маржа годин"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:33
+msgid "Counter measures"
+msgstr "Контрзаходи"
+
+#: org/libreplan/web/common/ConfigurationController.java:1442
+msgid "Only {0} allowed"
+msgstr "Дозволено лише {0}"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:30
+#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:27
+msgid "Relationship"
+msgstr "Зв'язок"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:455
+msgid "Group path"
+msgstr "Шлях групи"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:232
+#: org/libreplan/web/templates/OrderTemplatesController.java:250
+msgid "Template saved"
+msgstr "Шаблон збережено"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1386
+#: org/libreplan/web/orders/OrderElementTreeController.java:320
+msgid "Not enough permissions to create templates"
+msgstr "Недостатньо дозволів для створення шаблонів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:209
+msgid "subcontratation date not specified"
+msgstr "дата субпідряду не вказана"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:152
+msgid "Apply tab changes"
+msgstr "Застосувати зміни вкладки"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul:96
+msgid "Overtime ratio"
+msgstr "Коефіцієнт понаднормових"
+
+#: org/libreplan/web/resources/criterion/CriterionAdminController.java:251
+msgid ""
+"This criterion type cannot be deleted because it is assigned to projects or "
+"resources"
+msgstr ""
+"Цей тип критерію не можна видалити, оскільки він призначений до проєктів або "
+"ресурсів"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:97
+msgid "Create & Assign"
+msgstr "Створити та призначити"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1010
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:297
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:140
+msgid "Worker"
+msgstr "Працівник"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1215
+msgid "Project margin: {0}% ({1} hours)={2} hours"
+msgstr "Маржа проєкту: {0}% ({1} год)={2} год"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:152
+msgid "1 or 7 is Sunday, or use names"
+msgstr "1 або 7 — неділя, або використовуйте назви"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:22
+msgid "Work Hours Types List"
+msgstr "Список типів робочих годин"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_jiraOrderElementSync.zul:39
+msgid "Sync with JIRA"
+msgstr "Синхронізація з JIRA"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:376
+msgid "UserDn"
+msgstr "UserDn"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:130
+msgid "Order should not be empty"
+msgstr "Проєкт не повинен бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:33
+#: libreplan-webapp/src/main/webapp/common/_listJobScheduling.zul:28
+msgid "Job group"
+msgstr "Група завдань"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:122
+msgid "Project progress percentage"
+msgstr "Відсоток прогресу проєкту"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:84
+msgid "Budget minus resources costs"
+msgstr "Бюджет мінус витрати на ресурси"
+
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:28
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:28
+msgid "New criterion"
+msgstr "Новий критерій"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:58
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:61
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:164
+msgid "General data"
+msgstr "Загальні дані"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationCommand.java:47
+msgid "Advanced allocation"
+msgstr "Розширений розподіл"
+
+#: libreplan-webapp/src/main/webapp/logs/_logsFilter.zul:22
+msgid "Select required issue/risk name and press filter button"
+msgstr "Виберіть потрібну назву проблеми/ризику та натисніть кнопку фільтра"
+
+#: org/libreplan/web/common/CustomMenuController.java:370
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:35
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:59
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:69
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:201
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:71
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:22
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:53
+msgid "Materials"
+msgstr "Матеріали"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:86
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:65
+msgid "Identification"
+msgstr "Ідентифікація"
+
+#: org/libreplan/web/workreports/WorkReportTypeModel.java:433
+msgid "There is another timesheet template with the same code"
+msgstr "Існує інший шаблон табеля з таким самим кодом"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:118
+msgid "Bound user"
+msgstr "Прив'язаний користувач"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:251
+msgid "progress type name is already in use"
+msgstr "назва типу прогресу вже використовується"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:124
+msgid "Project details page"
+msgstr "Сторінка деталей проєкту"
+
+#: org/libreplan/web/orders/DetailsOrderElementController.java:120
+#: org/libreplan/web/orders/ProjectDetailsController.java:262
+msgid "Must be after 2010!"
+msgstr "Повинно бути після 2010!"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:52
+#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:43
+msgid "Remove calendar"
+msgstr "Видалити календар"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:209
+msgid "Reassignation"
+msgstr "Перепризначення"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1139
+msgid "Add measure"
+msgstr "Додати вимірювання"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:586
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1154
+msgid "You should select a start date for the exception"
+msgstr "Необхідно вибрати дату початку для виключення"
+
+#: org/libreplan/web/orders/OrderElementTreeModel.java:53
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:35
+msgid "New task"
+msgstr "Нове завдання"
+
+#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:159
+#: org/libreplan/web/reports/OrderCostsPerResourceModel.java:262
+msgid "All projects"
+msgstr "Усі проєкти"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:27
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:69
+msgid "Impact"
+msgstr "Вплив"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:119
+msgid "Welcome page"
+msgstr "Головна сторінка"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:61
+msgid "Sum of imputed hours in children tasks"
+msgstr "Сума зарахованих годин у дочірніх завданнях"
+
+#: org/libreplan/web/tree/TreeController.java:1017
+msgid "cannot be negative"
+msgstr "не може бути від'ємним"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLine.java:336
+msgid "Code already included in Hours Group codes"
+msgstr "Код вже включено в коди груп годин"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:21
+msgid "LibrePlan: Work And Progress Per Project"
+msgstr "LibrePlan: Робота та прогрес за проєктом"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:124
+msgid "Finish hour"
+msgstr "Година завершення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:190
+msgid "Assigned Label Type cannot be repeated in a Timesheet Template."
+msgstr "Призначений тип мітки не може повторюватися в шаблоні табелю."
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:148
+msgid "The admin's account password remains the default one. This is insecure"
+msgstr ""
+"Пароль облікового запису адміністратора залишається стандартним. Це "
+"небезпечно"
+
+#: org/libreplan/web/subcontract/SubcontractedTasksController.java:208
+msgid "Subcontracted task sent successfully"
+msgstr "Субпідрядне завдання успішно надіслано"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:39
+msgid "Filter timesheet lines by"
+msgstr "Фільтрувати рядки табелю за"
+
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:536
+msgid ""
+"Machine cannot be deleted. Machine is allocated to a project or contains "
+"imputed hours"
+msgstr ""
+"Неможливо видалити машину. Машина розподілена на проєкт або містить "
+"зараховані години"
+
+#: org/libreplan/web/tree/TreeComponent.java:44
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:31
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:31
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:895
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:38
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:62
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:83
+#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:37
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:102
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:54
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:119
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:27
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:30
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:24
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:24
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:29
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:28
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:40
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:26
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:57
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:220
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:304
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:33
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:65
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:75
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:51
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:47
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:90
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:78
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:176
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:56
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:27
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:49
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:79
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:54
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:76
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:184
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:55
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:38
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:37
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:45
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:46
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:71
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:26
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:121
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:96
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:101
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:99
+msgid "Code"
+msgstr "Код"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1122
+msgid "Please, enter a valid effort"
+msgstr "Будь ласка, введіть коректне трудовитрати"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesModel.java:128
+msgid "{0} (max: {1})"
+msgstr "{0} (макс: {1})"
+
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:60
+msgid "Task properties"
+msgstr "Властивості завдання"
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:483
+#: org/libreplan/web/planner/order/SubcontractCommand.java:53
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:64
+msgid "Subcontract"
+msgstr "Субпідряд"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:446
+msgid "The code must be unique."
+msgstr "Код повинен бути унікальним."
+
+#: libreplan-webapp/src/main/webapp/common/components/schedulingStateToggler.zul:33
+msgid "Unschedule"
+msgstr "Зняти планування"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:224
+msgid "Completed: {0}%"
+msgstr "Завершено: {0}%"
+
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:27
+msgid "Work hour type data"
+msgstr "Дані типу робочих годин"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/ResourceCalendar.java:74
+msgid "Capacity must be a positive integer number"
+msgstr "Потужність повинна бути додатним цілим числом"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:325
+msgid "Enable LDAP authentication"
+msgstr "Увімкнути автентифікацію LDAP"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:163
+msgid "End Date"
+msgstr "Дата завершення"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1662
+msgid "Not configurable"
+msgstr "Не налаштовується"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:693
+msgid "Progress that are reported by quality forms cannot be modified"
+msgstr "Прогрес, що звітується формами якості, не може бути змінено"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:194
+msgid "Estimated time for \"{0}\" issue is 0"
+msgstr "Оціночний час для завдання \"{0}\" дорівнює 0"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:701
+msgid "Calculated progress cannot be removed"
+msgstr "Розрахований прогрес не може бути видалено"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:75
+msgid "Template contents"
+msgstr "Вміст шаблону"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:34
+msgid "Personal data"
+msgstr "Персональні дані"
+
+#: libreplan-webapp/src/main/webapp/common/concurrentModification.zul:31
+msgid "Please try it again."
+msgstr "Будь ласка, спробуйте ще раз."
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:979
+msgid "Worker and bound user deleted"
+msgstr "Працівника та прив'язаного користувача видалено"
+
+#: org/libreplan/web/users/settings/SettingsController.java:161
+msgid "Max value = 999"
+msgstr "Макс. значення = 999"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:835
+msgid "Index fields and labels must be unique and consecutive"
+msgstr "Поля індексу та мітки повинні бути унікальними та послідовними"
+
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationModel.java:458
+msgid "( max: {0} )"
+msgstr "( макс: {0} )"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:144
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:31
+msgid "Show labels"
+msgstr "Показати мітки"
+
+#: org/libreplan/web/calendars/BaseCalendarModel.java:601
+msgid "Could not save the new calendar"
+msgstr "Не вдалося зберегти новий календар"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationCommand.java:71
+msgid "Resource allocation"
+msgstr "Розподіл ресурсів"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:72
+msgid "Page down"
+msgstr "Сторінка вниз"
+
+#: org/libreplan/web/planner/order/OrderPlanningController.java:311
+msgid "filtering"
+msgstr "фільтрація"
+
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:29
+msgid "Predefined"
+msgstr "Попередньо визначений"
+
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:213
+#: org/libreplan/web/resources/worker/CriterionsController.java:244
+msgid "Invaldid End Date. New End Date must be after current End Date "
+msgstr ""
+"Невірна дата завершення. Нова дата завершення повинна бути після поточної "
+"дати завершення"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_calendar.zul:49
+#: libreplan-webapp/src/main/webapp/resources/machine/_calendar.zul:40
+msgid "Edit Calendar"
+msgstr "Редагувати календар"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:130
+msgid "{0} 2nd fortnight"
+msgstr "{0} 2-га половина місяця"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1055
+msgid ""
+"This project is a subcontracted project. If you delete it, you won't be able "
+"to report progress anymore. Are you sure?"
+msgstr ""
+"Цей проєкт є субпідрядним проєктом. Якщо ви його видалите, ви більше не "
+"зможете звітувати про прогрес. Ви впевнені?"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:67
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:77
+msgid "Version"
+msgstr "Версія"
+
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:25
+msgid "Filter by"
+msgstr "Фільтрувати за"
+
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:189
+#: org/libreplan/web/resources/worker/CriterionsController.java:196
+msgid "This criterion type cannot have multiple values in the same period"
+msgstr "Цей тип критерію не може мати кілька значень в одному періоді"
+
+#: libreplan-webapp/src/main/webapp/common/layout/timeout.zul:27
+msgid "Your session has expired because of inactivity. Please log in again."
+msgstr "Ваш сеанс завершився через неактивність. Будь ласка, увійдіть знову."
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:51
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:53
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:55
+msgid "Estimated days"
+msgstr "Оціночні дні"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:37
+msgid "The formats supported for import are MPP and PLANNER files."
+msgstr "Підтримувані формати для імпорту — файли MPP та PLANNER."
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetDTO.java:129
+msgid "{0} 1st fortnight"
+msgstr "{0} 1-ша половина місяця"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/ResourceCalendar.java:79
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:167
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionSatisfaction.java:206
+msgid "resource not specified"
+msgstr "ресурс не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:56
+msgid "WBS (tasks)"
+msgstr "СРР (завдання)"
+
+#: org/libreplan/web/common/ConfigurationController.java:329
+msgid "LDAP connection was successful"
+msgstr "Підключення до LDAP успішне"
+
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:67
+msgid "Labels list"
+msgstr "Список міток"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:442
+msgid "last timesheet line sequence code not specified"
+msgstr "код останньої послідовності рядка табелю не вказано"
+
+#: org/libreplan/web/common/CustomMenuController.java:511
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:39
+msgid "Total Worked Hours By Resource In A Month"
+msgstr "Загальні відпрацьовані години за ресурсом за місяць"
+
+#: libreplan-webapp/src/main/webapp/resources/criterions/criterions.zul:24
+msgid "LibrePlan: Criteria"
+msgstr "LibrePlan: Критерії"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:888
+#: org/libreplan/web/orders/OrderCRUDController.java:1086
+#: org/libreplan/web/resourceload/ResourceLoadController.java:1058
+msgid "You don't have read access to this project"
+msgstr "У вас немає доступу на читання цього проєкту"
+
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:616
+msgid "Machines limit reached"
+msgstr "Досягнуто ліміт машин"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:36
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:51
+msgid "Last expense"
+msgstr "Остання витрата"
+
+#: org/libreplan/web/exceptionDays/CalendarExceptionTypeCRUDController.java:211
+msgid "Cannot remove the predefined calendar exception day \"{0}\""
+msgstr ""
+"Неможливо видалити попередньо визначений день виключення календаря \"{0}\""
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:208
+msgid ""
+"Please use some of the compatible browsers: Chrome, Firefox, Safari or "
+"Epiphany."
+msgstr ""
+"Будь ласка, використовуйте один із сумісних браузерів: Chrome, Firefox, "
+"Safari або Epiphany."
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:40
+msgid "Company name"
+msgstr "Назва компанії"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_editExternalCompany.zul:28
+msgid "Company data"
+msgstr "Дані компанії"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:61
+msgid "Job class name"
+msgstr "Назва класу завдань"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:277
+msgid "Start hour cannot be greater than finish hour"
+msgstr "Година початку не може бути більшою за годину завершення"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:100
+msgid "Criterion requirements"
+msgstr "Вимоги до критеріїв"
+
+#: libreplan-webapp/src/main/webapp/orders/_ordersTab.zul:34
+msgid "Save Project"
+msgstr "Зберегти проєкт"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:725
+msgid ""
+"Spread progress cannot be changed if there is a consolidation in any "
+"progress assignment from root task"
+msgstr ""
+"Прогрес розподілу не може бути змінено, якщо є консолідація в будь-якому "
+"призначенні прогресу з кореневого завдання"
+
+#: libreplan-webapp/src/main/webapp/planner/reassign.zul:31
+msgid "Reassigning"
+msgstr "Перепризначення"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:107
+msgid "The name is not valid, the name must not be null "
+msgstr "Назва недійсна, назва не повинна бути порожньою"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:140
+msgid "Assign materials"
+msgstr "Призначити матеріали"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:32
+msgid "CreatedBy"
+msgstr "Створив"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:83
+msgid "Personal timesheets peridocity"
+msgstr "Періодичність персональних табелів"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:54
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:66
+msgid "Report progress"
+msgstr "Звітувати про прогрес"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:141
+msgid "Task assigned to resource emails job"
+msgstr "Завдання, призначене для надсилання е-пошти ресурсу"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:74
+msgid "Unindent selected task"
+msgstr "Зменшити відступ вибраного завдання"
+
+#: org/libreplan/web/orders/assigntemplates/TemplateFinderPopup.java:134
+msgid "Choosing Template"
+msgstr "Вибір шаблону"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:59
+msgid "Work description"
+msgstr "Опис роботи"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:236
+msgid "MonteCarlo method"
+msgstr "Метод Монте-Карло"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:302
+msgid ""
+"Another task in the same branch is already reporting progress for this "
+"quality form"
+msgstr ""
+"Інше завдання в тій самій гілці вже звітує прогрес для цієї форми якості"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:165
+msgid "Import roster for department {0}"
+msgstr "Імпортувати розклад для відділу {0}"
+
+#: org/libreplan/web/importers/ProjectImportController.java:115
+msgid ": Task import successfully!"
+msgstr ": Завдання успішно імпортовано!"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:90
+msgid "job class name not specified"
+msgstr "назву класу завдань не вказано"
+
+#: org/libreplan/web/orders/TreeElementOperationsController.java:52
+msgid "Please select a task"
+msgstr "Будь ласка, виберіть завдання"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:74
+msgid "Date Finish"
+msgstr "Дата завершення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:432
+msgid "Criterion Type name is already being used"
+msgstr "Назва типу критерію вже використовується"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/qualityForms.zul:22
+msgid "LibrePlan: Quality Forms"
+msgstr "LibrePlan: Форми якості"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:39
+msgid "Destination scenario"
+msgstr "Цільовий сценарій"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:328
+msgid "Use LDAP roles"
+msgstr "Використовувати ролі LDAP"
+
+#: org/libreplan/web/orders/JiraSynchronizationController.java:178
+#: org/libreplan/web/orders/JiraSynchronizationController.java:225
+#: org/libreplan/web/common/ConfigurationController.java:413
+#: org/libreplan/web/common/ConfigurationController.java:418
+msgid "Cannot connect to JIRA server"
+msgstr "Неможливо підключитися до сервера JIRA"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:222
+msgid "Project: {0}"
+msgstr "Проєкт: {0}"
+
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:184
+#: org/libreplan/web/resources/worker/CriterionsController.java:192
+msgid "Criterion already assigned"
+msgstr "Критерій вже призначено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CustomerCommunication.java:132
+msgid "project not specified"
+msgstr "проєкт не вказано"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeModel.java:342
+msgid "Name of criterion is empty."
+msgstr "Назва критерію порожня."
+
+#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:41
+msgid "Tim product code"
+msgstr "Код продукту Tim"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:605
+msgid "My account"
+msgstr "Мій обліковий запис"
+
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:41
+msgid "Add stretch"
+msgstr "Додати розтягнення"
+
+#: org/libreplan/web/scenarios/ScenarioCRUDController.java:213
+#: org/libreplan/web/common/TemplateController.java:133
+msgid "error doing reassignment: {0}"
+msgstr "помилка при перепризначенні: {0}"
+
+#: org/libreplan/web/common/ConfigurationController.java:1015
+msgid "It can not be deleted. At least one sequence is necessary."
+msgstr "Неможливо видалити. Необхідна принаймні одна послідовність."
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:381
+msgid ""
+"In the heading part, index labels and fields must be unique and consecutive"
+msgstr ""
+"У заголовній частині мітки індексів та поля повинні бути унікальними та "
+"послідовними"
+
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:22
+msgid "Calendars List"
+msgstr "Список календарів"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:112
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:120
+#: libreplan-webapp/src/main/webapp/planner/order.zul:107
+msgid "Consolidated"
+msgstr "Консолідований"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:276
+msgid "cannot be checked until the previous item is checked before"
+msgstr "не може бути відмічено, доки попередній елемент не відмічено"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:445
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:38
+msgid "Alpha"
+msgstr "Альфа"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:834
+msgid ""
+"Periods available depend on the satisfaction of the criteria of resources "
+"and their calendars."
+msgstr ""
+"Доступні періоди залежать від задоволення критеріїв ресурсів та їхніх "
+"календарів."
+
+#: org/libreplan/web/dashboard/DashboardController.java:281
+msgid "Task Status"
+msgstr "Статус завдання"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:28
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:39
+msgid "Category name"
+msgstr "Назва категорії"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:30
+msgid "Inherited labels"
+msgstr "Успадковані мітки"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:51
+msgid "Direct labels"
+msgstr "Прямі мітки"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:124
+msgid "Add new criterion requirement"
+msgstr "Додати нову вимогу критерію"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:93
+msgid "Select language"
+msgstr "Вибрати мову"
+
+#: org/libreplan/web/common/ConfigurationController.java:468
+msgid "Connection unsuccessful"
+msgstr "Підключення невдале"
+
+#: org/libreplan/web/orders/TreeElementOperationsController.java:248
+msgid "Operation cannot be done"
+msgstr "Операцію неможливо виконати"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:402
+msgid "Duplicate value AdvanceAssignment for order element of \"{0}\""
+msgstr "Дубльоване значення призначення прогресу для елемента проєкту \"{0}\""
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:43
+msgid "Number of finished applications"
+msgstr "Кількість завершених заявок"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:248
+msgid "SV"
+msgstr "SV"
+
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:29
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:109
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:78
+msgid "Priority"
+msgstr "Пріоритет"
+
+#: org/libreplan/web/common/ConfigurationController.java:1283
+msgid ""
+"Periocity cannot be changed because there is already any personal timesheet "
+"stored"
+msgstr ""
+"Періодичність не може бути змінена, оскільки вже є збережений персональний "
+"табель"
+
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:169
+#: org/libreplan/web/reports/SchedulingProgressPerOrderController.java:195
+msgid "SPREAD"
+msgstr "РОЗПОДІЛ"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:218
+msgid "Resources budget"
+msgstr "Бюджет ресурсів"
+
+#: org/libreplan/web/common/ConfigurationController.java:1460
+msgid "Only digits allowed"
+msgstr "Допускаються лише цифри"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:41
+msgid "Show all reported hours"
+msgstr "Показати всі зараховані години"
+
+#: libreplan-webapp/src/main/webapp/unittypes/unitTypes.zul:21
+msgid "LibrePlan: Material Units"
+msgstr "LibrePlan: Одиниці матеріалів"
+
+#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:20
+msgid "LibrePlan: Tim import export info"
+msgstr "LibrePlan: Інформація імпорту/експорту Tim"
+
+#: org/libreplan/web/common/CustomMenuController.java:482
+msgid "Received From Subcontractors"
+msgstr "Отримано від субпідрядників"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1207
+msgid "Invalid date. Date must be unique for this Progress Assignment"
+msgstr ""
+"Недійсна дата. Дата повинна бути унікальною для цього призначення прогресу"
+
+#: org/libreplan/web/common/ConfigurationController.java:332
+msgid "Cannot connect to LDAP server"
+msgstr "Неможливо підключитися до сервера LDAP"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:447
+msgid "Schedule from deadline to start"
+msgstr "Планувати від кінцевого терміну до початку"
+
+#: org/libreplan/web/common/components/finders/ResourceInExpenseSheetBandboxFinder.java:44
+msgid "Resource name (Resource code)"
+msgstr "Назва ресурсу (Код ресурсу)"
+
+#: org/libreplan/web/planner/reassign/Type.java:43
+msgid "From today"
+msgstr "Від сьогодні"
+
+#: org/libreplan/web/common/components/finders/QualityFormBandboxFinder.java:50
+#: org/libreplan/web/common/components/finders/CriterionBandboxFinder.java:44
+#: org/libreplan/web/common/components/finders/LabelBandboxFinder.java:51
+#: org/libreplan/web/common/components/finders/ResourceInExpenseSheetBandboxFinder.java:44
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:44
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:53
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:38
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:53
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:169
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:31
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:26
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:52
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:27
+#: libreplan-webapp/src/main/webapp/templates/_advances.zul:36
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:50
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:49
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:123
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:70
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:91
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:172
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:35
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:51
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:56
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:94
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:94
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:46
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:68
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:44
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:27
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:87
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:129
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:95
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:136
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:108
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:152
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:93
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:136
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:178
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:148
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:191
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:99
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:142
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:33
+msgid "Type"
+msgstr "Тип"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:210
+msgid "No roster-exceptions found in the response"
+msgstr "У відповіді не знайдено виключень розкладу"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:91
+msgid "Invalid value. Default Max Value cannot be empty"
+msgstr ""
+"Невірне значення. Максимальне значення за замовчуванням не може бути порожнім"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:121
+msgid "cost category not specified"
+msgstr "категорію витрат не вказано"
+
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:31
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:31
+#: org/libreplan/web/planner/TaskElementAdapter.java:860
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:122
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:38
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:56
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:51
+msgid "State"
+msgstr "Стан"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:182
+msgid "Not bound"
+msgstr "Не прив'язано"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:171
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:216
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:246
+msgid "Normal Effort"
+msgstr "Нормальні трудовитрати"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:68
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:49
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:105
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:386
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:175
+msgid "Password"
+msgstr "Пароль"
+
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:22
+msgid "Progress Types List"
+msgstr "Список типів прогресу"
+
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:49
+msgid "Select the elements to import into LibrePlan"
+msgstr "Виберіть елементи для імпорту в LibrePlan"
+
+#: org/libreplan/web/resources/criterion/CriterionAdminController.java:205
+msgid "Criterion Types"
+msgstr "Типи критеріїв"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:534
+#: org/libreplan/web/orders/OrderCRUDController.java:1412
+#: org/libreplan/web/orders/ProjectDetailsController.java:237
+#: org/libreplan/web/orders/OrderElementTreeController.java:750
+#: org/libreplan/web/workreports/WorkReportQueryController.java:139
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:784
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:407
+#: org/libreplan/web/planner/company/CompanyPlanningController.java:293
+#: org/libreplan/web/planner/order/OrderPlanningController.java:345
+msgid "must be after start date"
+msgstr "повинна бути після дати початку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:273
+msgid "description value: the timesheet has some description field missing"
+msgstr "значення опису: в табелі відсутнє поле опису"
+
+#: org/libreplan/web/common/CustomMenuController.java:569
+msgid "Change Password"
+msgstr "Змінити пароль"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:43
+msgid "Optimistic"
+msgstr "Оптимістичний"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:125
+msgid "Time tracking"
+msgstr "Облік часу"
+
+#: org/libreplan/web/planner/milestone/AddMilestoneCommand.java:67
+msgid "Add Milestone"
+msgstr "Додати віху"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1088
+msgid ""
+"Progress measurements that are reported by quality forms cannot be removed"
+msgstr ""
+"Вимірювання прогресу, що звітуються формами якості, не можуть бути видалені"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:214
+msgid "Calendar exception days"
+msgstr "Дні виключень календаря"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:63
+msgid "Zoom"
+msgstr "Масштаб"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:509
+msgid "Application properties"
+msgstr "Властивості застосунку"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:292
+msgid "Root calendar"
+msgstr "Кореневий календар"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:124
+#: org/libreplan/importers/ExportTimesheetsToTim.java:92
+#: org/libreplan/importers/ExportTimesheetsToTim.java:135
+msgid "Tim connector not found"
+msgstr "Конектор Tim не знайдено"
+
+#: org/libreplan/web/common/components/NewAllocationSelector.java:75
+msgid "generic machines allocation"
+msgstr "узагальнений розподіл машин"
+
+#: org/libreplan/web/planner/allocation/AllocationRow.java:829
+msgid "In the available periods {0} only {1} hours are available."
+msgstr "У доступних періодах {0} доступно лише {1} годин."
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:107
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:36
+msgid "Observations"
+msgstr "Спостереження"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:28
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:76
+msgid "Risk score"
+msgstr "Оцінка ризику"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:339
+msgid "last hours cost sequence code not specified"
+msgstr "код останньої послідовності вартості годин не вказано"
+
+#: org/libreplan/web/common/converters/ConverterFactory.java:64
+msgid "Not found converter for {0}"
+msgstr "Конвертер для {0} не знайдено"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:30
+msgid "Machine data"
+msgstr "Дані машини"
+
+#: org/libreplan/web/common/ConfigurationController.java:344
+msgid "Please select a connector to test it"
+msgstr "Будь ласка, виберіть конектор для тестування"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector_combo.zul:26
+msgid "Select criteria set or a resource to add"
+msgstr "Виберіть набір критеріїв або ресурс для додавання"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:301
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:55
+msgid "Delivery date"
+msgstr "Дата доставки"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1101
+msgid "Consolidated progress measurement cannot be removed"
+msgstr "Консолідоване вимірювання прогресу не може бути видалено"
+
+#: org/libreplan/web/common/CustomMenuController.java:462
+msgid "Edit E-mail Templates"
+msgstr "Редагувати шаблони е-пошти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:125
+msgid "label type name is already in use"
+msgstr "назва типу мітки вже використовується"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:22
+msgid "LibrePlan: Send To Customers"
+msgstr "LibrePlan: Надіслати замовникам"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:269
+msgid "Significant"
+msgstr "Значний"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:237
+msgid "Budget margin"
+msgstr "Бюджетний запас"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:126
+msgid "last expense sheet line sequence code not specified"
+msgstr "код останньої послідовності рядка аркуша витрат не вказано"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:665
+msgid "Progress that are reported by quality forms can not be modified"
+msgstr "Прогрес, що звітується формами якості, не може бути змінено"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:141
+msgid "Show reported hours"
+msgstr "Показати зараховані години"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:73
+msgid "Own exception"
+msgstr "Власне виключення"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:59
+msgid "Zoom level"
+msgstr "Рівень масштабу"
+
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:39
+#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:29
+#: libreplan-webapp/src/main/webapp/orders/_synchronizationInfo.zul:26
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:202
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:91
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:143
+msgid "Close"
+msgstr "Закрити"
+
+#: libreplan-webapp/src/main/webapp/templates/templates.zul:22
+msgid "LibrePlan: Templates"
+msgstr "LibrePlan: Шаблони"
+
+#: org/libreplan/web/resourceload/ResourceLoadController.java:551
+msgid "Resources or criteria"
+msgstr "Ресурси або критерії"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:47
+msgid "Please remember that only saved changes will be printed"
+msgstr "Пам'ятайте, що будуть надруковані лише збережені зміни"
+
+#: org/libreplan/web/common/CustomMenuController.java:336
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:579
+msgid "Machines"
+msgstr "Машини"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:27
+msgid "Select criteria set or specific resources for allocation"
+msgstr "Виберіть набір критеріїв або конкретні ресурси для розподілу"
+
+#: org/libreplan/web/common/ConfigurationModel.java:254
+msgid "Some sequences to be removed do not exist"
+msgstr "Деякі послідовності для видалення не існують"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/ResourcesCostCategoryAssignment.java:128
+msgid "cost assignment's resource not specified"
+msgstr "ресурс призначення витрат не вказано"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:342
+msgid "Expand/Collapse all"
+msgstr "Розгорнути/Згорнути все"
+
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:775
+msgid "Text field"
+msgstr "Текстове поле"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:164
+msgid "Projects since"
+msgstr "Проєкти з"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:516
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:526
+msgid "Repeated Hours Group code {0} in Project {1}"
+msgstr "Повторюваний код групи годин {0} у проєкті {1}"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:44
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:52
+msgid "Apply"
+msgstr "Застосувати"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:468
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementModel.java:293
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:80
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:137
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:142
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheetLine.java:137
+msgid "date not specified"
+msgstr "дату не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/Configuration.java:159
+msgid "company code not specified"
+msgstr "код компанії не вказано"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:57
+msgid "Help/Info pages are not generated"
+msgstr "Сторінки довідки/інформації не згенеровані"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:84
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:27
+msgid "Allocation configuration"
+msgstr "Конфігурація розподілу"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:38
+msgid "Source scenario"
+msgstr "Вихідний сценарій"
+
+#: org/libreplan/web/common/TemplateController.java:245
+msgid "A new version "
+msgstr "Нова версія"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:101
+msgid "quality form type not specified"
+msgstr "тип форми якості не вказано"
+
+#: org/libreplan/web/common/CustomMenuController.java:400
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:878
+msgid "Timesheets Templates"
+msgstr "Шаблони табелів"
+
+#: libreplan-webapp/src/main/webapp/common/layout/_customMenu.zul:82
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:65
+msgid "en"
+msgstr "uk"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:243
+msgid "state not specified"
+msgstr "стан не вказано"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:449
+msgid "Create Worker"
+msgstr "Створити працівника"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:31
+msgid "Available hours"
+msgstr "Доступні години"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:640
+msgid "{0} already assigned to resource allocation list"
+msgstr "{0} вже призначено до списку розподілу ресурсів"
+
+#: org/libreplan/web/planner/tabs/LogsTabCreator.java:89
+#: org/libreplan/web/planner/tabs/LogsTabCreator.java:106
+#: org/libreplan/web/planner/tabs/LogsTabCreator.java:121
+#: org/libreplan/web/planner/tabs/LogsTabCreator.java:138
+msgid "Logs"
+msgstr "Журнали"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:302
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:338
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:48
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:114
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:131
+msgid "Communication date"
+msgstr "Дата повідомлення"
+
+#: org/libreplan/web/templates/OrderTemplatesController.java:306
+#: org/libreplan/web/common/CustomMenuController.java:313
+msgid "Templates"
+msgstr "Шаблони"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:79
+msgid "Indent selected task"
+msgstr "Збільшити відступ вибраного завдання"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1039
+#: org/libreplan/web/orders/OrderElementTreeController.java:776
+msgid ""
+"You can not remove the project \"{0}\" because this one has imputed expense "
+"sheets."
+msgstr ""
+"Неможливо видалити проєкт \"{0}\", оскільки він має зараховані аркуші витрат."
+
+#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:454
+msgid "Split new assignment"
+msgstr "Розділити нове призначення"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:97
+msgid "Progress Evolution"
+msgstr "Еволюція прогресу"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:264
+msgid "Project type"
+msgstr "Тип проєкту"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:95
+msgid "Total other"
+msgstr "Всього інше"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:548
+msgid ""
+"there is a timesheet line in another work report marking as finished the "
+"same task"
+msgstr ""
+"є рядок табелю в іншому табелі, що позначає те саме завдання як завершене"
+
+#: org/libreplan/web/common/components/bandboxsearch/BandboxMultipleSearch.java:231
+msgid "filter already exists"
+msgstr "фільтр вже існує"
+
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderTemplate.java:72
+msgid "template calendar not specified"
+msgstr "шаблон календаря не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskMilestone.java:122
+msgid "a milestone cannot have a task associated"
+msgstr "віха не може мати пов'язане завдання"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:77
+msgid "Imputed expenses"
+msgstr "Зараховані витрати"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1349
+#: org/libreplan/web/orders/OrderElementTreeController.java:539
+#: org/libreplan/web/templates/TemplatesTreeController.java:69
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:335
+#: org/libreplan/web/subcontract/CustomerCommunicationCRUDController.java:196
+#: org/libreplan/web/subcontract/SubcontractorCommunicationCRUDController.java:232
+#: org/libreplan/web/common/Util.java:668
+#: org/libreplan/web/limitingresources/QueueComponent.java:502
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:26
+#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:25
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:58
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:45
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:36
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:55
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:26
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:43
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:49
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:41
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:93
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:151
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:37
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:37
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:42
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:47
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:28
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:33
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:40
+msgid "Edit"
+msgstr "Редагувати"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1645
+msgid "Regular project"
+msgstr "Звичайний проєкт"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:81
+msgid "length not specified"
+msgstr "довжину не вказано"
+
+#: org/libreplan/web/resources/criterion/CriterionTreeController.java:334
+msgid "references"
+msgstr "посилання"
+
+#: org/libreplan/web/common/components/NewAllocationSelector.java:93
+msgid "specific allocation"
+msgstr "конкретний розподіл"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:20
+msgid "LibrePlan: Received From Customers"
+msgstr "LibrePlan: Отримано від замовників"
+
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:130
+msgid "Timing"
+msgstr "Хронометраж"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormItem.java:72
+msgid "quality form item name not specified or empty"
+msgstr "назву елемента форми якості не вказано або порожня"
+
+#: org/libreplan/web/scenarios/TransferOrdersModel.java:148
+msgid "Please, select a destination scenario"
+msgstr "Будь ласка, виберіть цільовий сценарій"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:51
+msgid "Subcontracting communication date"
+msgstr "Дата повідомлення субпідряду"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:110
+msgid "total not specified"
+msgstr "загальну суму не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:152
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceMeasurement.java:165
+msgid "The current value must be less than the max value."
+msgstr "Поточне значення повинно бути менше максимального значення."
+
+#: org/libreplan/web/dashboard/DashboardController.java:183
+msgid "Task deadline violations"
+msgstr "Порушення кінцевих термінів завдань"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/Order.java:371
+msgid "the project must have a deadline"
+msgstr "проєкт повинен мати кінцевий термін"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:414
+msgid "UserId"
+msgstr "Ідентифікатор користувача"
+
+#: org/libreplan/web/common/CustomMenuController.java:477
+msgid "Send To Subcontractors"
+msgstr "Надіслати субпідрядникам"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:22
+msgid "Tim sync information"
+msgstr "Інформація синхронізації Tim"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:22
+msgid "Virtual Workers Groups List"
+msgstr "Список груп віртуальних працівників"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:524
+msgid "the same task is marked as finished by more than one timesheet line"
+msgstr "те саме завдання позначено як завершене більш ніж одним рядком табелю"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:149
+msgid "Go to edit user window"
+msgstr "Перейти до вікна редагування користувача"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:169
+msgid "Default Label"
+msgstr "Мітка за замовчуванням"
+
+#: org/libreplan/web/planner/allocation/FormBinder.java:339
+msgid ""
+"The original workable days value {0} cannot be modified as it has "
+"consolidations"
+msgstr ""
+"Початкове значення робочих днів {0} не може бути змінено, оскільки є "
+"консолідації"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:506
+msgid "Select for automatic queuing"
+msgstr "Вибрати для автоматичної черги"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:167
+msgid "Effort"
+msgstr "Трудовитрати"
+
+#: org/libreplan/web/users/dashboard/ExpensesAreaController.java:80
+msgid "Delete expense sheet \"{0}\". Are you sure?"
+msgstr "Видалити аркуш витрат \"{0}\". Ви впевнені?"
+
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:279
+msgid "Please, select a calendar"
+msgstr "Будь ласка, виберіть календар"
+
+#: org/libreplan/web/orders/TreeElementOperationsController.java:240
+msgid "Confirm create template"
+msgstr "Підтвердити створення шаблону"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:289
+msgid "Derived of calendar {0}"
+msgstr "Похідний від календаря {0}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:419
+msgid "a disabled resource has enabled subresources"
+msgstr "вимкнений ресурс має увімкнені підресурси"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:176
+msgid "Ok"
+msgstr "Ок"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:69
+msgid "Task Quality Form item name not specified"
+msgstr "Назву елемента форми якості завдання не вказано"
+
+#: org/libreplan/web/common/CustomMenuController.java:361
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:215
+msgid "Progress Types"
+msgstr "Типи прогресу"
+
+#: org/libreplan/web/common/ConfigurationController.java:1564
+msgid "The only current supported formats are png and jpeg"
+msgstr "Єдині підтримувані формати — png та jpeg"
+
+#: org/libreplan/web/common/BaseCRUDController.java:320
+msgid "{0} \"{1}\" could not be deleted, it was already removed"
+msgstr "{0} \"{1}\" не вдалося видалити, його вже було видалено"
+
+#: org/libreplan/web/costcategories/ResourcesCostCategoryAssignmentController.java:108
+msgid "A category must be selected"
+msgstr "Необхідно вибрати категорію"
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:22
+#: libreplan-webapp/src/main/webapp/common/error.zul:21
+msgid "LibrePlan: Runtime Error"
+msgstr "LibrePlan: Помилка виконання"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:175
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:87
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:128
+msgid "already assigned"
+msgstr "вже призначено"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:41
+msgid "Data"
+msgstr "Дані"
+
+#: libreplan-webapp/src/main/webapp/common/layout/template.zul:84
+msgid "scenario"
+msgstr "сценарій"
+
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:64
+msgid "Template Tree"
+msgstr "Дерево шаблонів"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1116
+msgid "inherited exception can not be removed"
+msgstr "успадковане виключення не може бути видалено"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:145
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:191
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:54
+msgid "Month"
+msgstr "Місяць"
+
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:61
+msgid "Precision"
+msgstr "Точність"
+
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:479
+msgid "Automatic"
+msgstr "Автоматично"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:150
+msgid "Earlier starting date"
+msgstr "Найраніша дата початку"
+
+#: org/libreplan/web/users/settings/PasswordController.java:98
+msgid "passwords can not be empty"
+msgstr "паролі не можуть бути порожніми"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:27
+msgid "Task Information"
+msgstr "Інформація про завдання"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:96
+msgid "Earliest date"
+msgstr "Найраніша дата"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:39
+msgid "Upload date"
+msgstr "Дата завантаження"
+
+#: libreplan-webapp/src/main/webapp/orders/_listHoursGroupCriterionRequirement.zul:22
+msgid "Criteria Requirement"
+msgstr "Вимога критерію"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:105
+msgid "Up"
+msgstr "Вгору"
+
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationCommand.java:67
+#: libreplan-webapp/src/main/webapp/planner/order.zul:79
+msgid "Progress consolidation"
+msgstr "Консолідація прогресу"
+
+#: org/libreplan/web/exceptionDays/CalendarExceptionTypeModel.java:96
+msgid "Cannot remove {0}, since it is being used by some exception day"
+msgstr ""
+"Неможливо видалити {0}, оскільки він використовується деяким днем виключення"
+
+#: libreplan-webapp/src/main/webapp/common/accessForbidden.zul:38
+msgid "You do not have permissions to access to this page."
+msgstr "У вас немає прав доступу до цієї сторінки."
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:171
+msgid "type of work hours for JIRA connector cannot be disabled"
+msgstr "тип робочих годин для конектора JIRA не може бути вимкнено"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_workRelationships.zul:29
+#: libreplan-webapp/src/main/webapp/resources/worker/_localizations.zul:70
+#: libreplan-webapp/src/main/webapp/resources/worker/_editWorkRelationship.zul:26
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:53
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:59
+msgid "Ending date"
+msgstr "Дата завершення"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:106
+msgid "Original"
+msgstr "Оригінал"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:245
+msgid "Add Criterion"
+msgstr "Додати критерій"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:854
+msgid "Normal resource"
+msgstr "Звичайний ресурс"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:179
+msgid "There must be at least 2 stretches for doing interpolation"
+msgstr "Для виконання інтерполяції потрібно принаймні 2 розтягнення"
+
+#: org/libreplan/web/resources/criterion/CriterionsModel.java:217
+msgid "Criterion cannot be empty"
+msgstr "Критерій не може бути порожнім"
+
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:60
+msgid "New Template element"
+msgstr "Новий елемент шаблону"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1190
+msgid "Value is not valid. It must be smaller than max value"
+msgstr "Значення недійсне. Воно повинно бути менше максимального значення"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:47
+msgid "Last communication"
+msgstr "Останнє повідомлення"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:506
+msgid "Move"
+msgstr "Перемістити"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:22
+msgid "LibrePlan: Send To Subcontractors"
+msgstr "LibrePlan: Надіслати субпідрядникам"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:798
+msgid "All workers"
+msgstr "Усі працівники"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:34
+msgid "options"
+msgstr "параметри"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:210
+msgid "Progress Type"
+msgstr "Тип прогресу"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:36
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:82
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:109
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:39
+msgid "Assign"
+msgstr "Призначити"
+
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:29
+msgid "Category data"
+msgstr "Дані категорії"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:99
+msgid "Export"
+msgstr "Експорт"
+
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:452
+msgid "Total Hours"
+msgstr "Загальні години"
+
+#: org/libreplan/web/templates/TemplatesTree.java:43
+#: org/libreplan/web/templates/TemplatesTree.java:51
+msgid "New Description"
+msgstr "Новий опис"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:333
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:334
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationController.java:109
+#: org/libreplan/web/planner/consolidations/AdvanceConsolidationController.java:110
+msgid "Progress measurements"
+msgstr "Вимірювання прогресу"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementLabels.zul:90
+msgid "Create and assign label"
+msgstr "Створити та призначити мітку"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:27
+msgid "Add new configuration unit"
+msgstr "Додати новий блок конфігурації"
+
+#: org/libreplan/web/materials/MaterialsController.java:344
+msgid "Materials saved"
+msgstr "Матеріали збережено"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:86
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:121
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:31
+#: libreplan-webapp/src/main/webapp/templates/_materialAssignmentsBox.zul:30
+msgid "Unit type"
+msgstr "Тип одиниці"
+
+#: org/libreplan/web/email/EmailTemplateController.java:98
+msgid "E-mail template saved"
+msgstr "Шаблон е-пошти збережено"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:36
+msgid "Locations"
+msgstr "Місця розташування"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:45
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:46
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:45
+msgid "Subcontracting date"
+msgstr "Дата субпідряду"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:796
+msgid ""
+"You cannot remove the task \"{0}\" because it is the only child of its "
+"parent and its parent has tracked time or imputed expenses"
+msgstr ""
+"Неможливо видалити завдання \"{0}\", оскільки це єдиний дочірній елемент "
+"свого батька, а батько має відстежений час або зараховані витрати"
+
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:43
+msgid "Select report data"
+msgstr "Вибрати дані звіту"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:40
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:54
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:57
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:62
+#: libreplan-webapp/src/main/webapp/resources/search/_resourceFilter.zul:42
+msgid "to"
+msgstr "до"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:37
+msgid "Shrink to fit page width"
+msgstr "Стиснути до ширини сторінки"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:111
+msgid "Overtime"
+msgstr "Понаднормові"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:210
+msgid "Timesheet templates"
+msgstr "Шаблони табелів"
+
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:55
+msgid "Edit Template"
+msgstr "Редагувати шаблон"
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:61
+msgid ""
+"Open file HACKING.rst in project directory and read Part LibrePlan "
+"documentation generation, how to generate help/info pages"
+msgstr ""
+"Відкрийте файл HACKING.rst у каталозі проєкту та прочитайте розділ про "
+"генерацію документації LibrePlan, як генерувати сторінки довідки/інформації"
+
+#: org/libreplan/web/resources/worker/WorkerModel.java:428
+msgid ""
+"Please, allow Multiple Active Criteria in this type in order to use selected "
+"Assignment Strategy"
+msgstr ""
+"Будь ласка, дозвольте множинні активні критерії в цьому типі для "
+"використання вибраної стратегії призначення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:182
+msgid ""
+"interaction fields are empty and company is marked as interact with "
+"applications"
+msgstr ""
+"поля взаємодії порожні, а компанію позначено як таку, що взаємодіє із "
+"застосунками"
+
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:64
+msgid "Work done until ending date"
+msgstr "Робота виконана до дати завершення"
+
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:132
+msgid "Expense lines"
+msgstr "Рядки витрат"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:195
+msgid "Work"
+msgstr "Робота"
+
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:197
+#: org/libreplan/web/planner/tabs/PlanningTabCreator.java:225
+msgid "Projects Planning"
+msgstr "Планування проєктів"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:39
+msgid "Work done"
+msgstr "Виконана робота"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:112
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:242
+msgid "type of work hours not specified"
+msgstr "тип робочих годин не вказано"
+
+#: org/libreplan/web/importers/ProjectImportController.java:133
+msgid "The only current supported formats are mpp and planner."
+msgstr "Єдині підтримувані формати — mpp та planner."
+
+#: libreplan-webapp/src/main/webapp/common/pageNotFound.zul:45
+#: libreplan-webapp/src/main/webapp/common/accessForbidden.zul:45
 msgid "Go to init"
+msgstr "Перейти на початок"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:789
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:798
+msgid ""
+"There are unsaved changes in the current personal timesheet, please save "
+"before moving"
 msgstr ""
+"У поточному персональному табелі є незбережені зміни, будь ласка, збережіть "
+"перед переходом"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:253
+msgid "CPI"
+msgstr "CPI"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:113
+msgid "project sync info is already being used"
+msgstr "інформація синхронізації проєкту вже використовується"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/TypeOfWorkHours.java:128
+msgid "the type of work hours name has to be unique. It is already used"
+msgstr ""
+"назва типу робочих годин повинна бути унікальною. Вона вже використовується"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:146
+msgid "Show a notification when new LibrePlan versions are released"
+msgstr "Показувати сповіщення при виході нових версій LibrePlan"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:113
+msgid ""
+"The name is not valid, there is another progress type with the same name. "
+msgstr "Назва недійсна, інший тип прогресу вже має таку саму назву."
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:128
+msgid "Workable time"
+msgstr "Робочий час"
+
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:156
+msgid "label code is already being used"
+msgstr "код мітки вже використовується"
 
 #: org/libreplan/importers/JiraTimesheetSynchronizer.java:124
+msgid "Key for Order \"{0}\" is empty"
+msgstr "Ключ для проєкту \"{0}\" порожній"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:27
+msgid "External company"
+msgstr "Зовнішня компанія"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:87
+msgid "position not specified"
+msgstr "позицію не вказано"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:63
+msgid "Select template type"
+msgstr "Вибрати тип шаблону"
+
+#: org/libreplan/web/orders/labels/AssignedLabelsController.java:112
+msgid "please, select an item"
+msgstr "будь ласка, виберіть елемент"
+
+#: org/libreplan/web/resources/worker/CriterionsMachineController.java:233
+#: org/libreplan/web/resources/worker/CriterionsController.java:222
+msgid "Invalid Start Date. New Start Date must be earlier than End Date"
+msgstr ""
+"Невірна дата початку. Нова дата початку повинна бути раніше дати завершення"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:152
+msgid "must be a real positive number"
+msgstr "повинно бути дійсним додатним числом"
+
+#: org/libreplan/web/calendars/BaseCalendarModel.java:534
+msgid "Date cannot include the entire next work week"
+msgstr "Дата не може включати весь наступний робочий тиждень"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:76
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:167
+msgid "New"
+msgstr "Новий"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:95
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:113
+msgid "Deliver date"
+msgstr "Дата доставки"
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:387
+msgid ""
+"This resource allocation type is incompatible. The task has an associated "
+"order element which has a progress that is of type subcontractor. "
+msgstr ""
+"Цей тип розподілу ресурсів несумісний. Завдання має пов'язаний елемент "
+"проєкту з прогресом типу субпідрядника."
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:127
+msgid "Product code should not be empty"
+msgstr "Код продукту не повинен бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:22
+msgid "Label Types List"
+msgstr "Список типів міток"
+
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:55
+msgid "Work amount"
+msgstr "Обсяг роботи"
+
+#: org/libreplan/web/common/components/TwoWaySelector.java:108
+msgid "Unknown attribute '{0}' in class {1}"
+msgstr "Невідомий атрибут '{0}' у класі {1}"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:259
+msgid "Expenses cost"
+msgstr "Вартість витрат"
+
+#: org/libreplan/web/common/ConfigurationController.java:294
+msgid "Changes have been canceled"
+msgstr "Зміни скасовано"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:181
+msgid "Timesheet data missing job"
+msgstr "Завдання з відсутніми даними табелю"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:88
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:218
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:249
+msgid "Extra Effort"
+msgstr "Додаткові трудовитрати"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:31
+msgid "Planned start"
+msgstr "Плановий початок"
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:682
+msgid ""
+"IMPORTANT: Don't forget to communicate to subcontractor that his contract "
+"has been cancelled"
+msgstr ""
+"ВАЖЛИВО: Не забудьте повідомити субпідрядника про скасування його контракту"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:268
+msgid "Minor"
+msgstr "Незначний"
+
+#: org/libreplan/web/common/CustomMenuController.java:525
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:39
+msgid "Work And Progress Per Task"
+msgstr "Робота та прогрес за завданням"
+
+#: libreplan-business/src/main/java/org/libreplan/business/expensesheet/entities/ExpenseSheet.java:109
+msgid "total must be greater or equal than 0"
+msgstr "загальна сума повинна бути більше або дорівнювати 0"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractorCommunicationValue.java:73
+msgid "progress should be greater than 0% and less than 100%"
+msgstr "прогрес повинен бути більше 0% та менше 100%"
+
+#: org/libreplan/web/users/UserCRUDController.java:502
+msgid "User limit reached"
+msgstr "Досягнуто ліміт користувачів"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:52
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:59
+msgid "Allocations"
+msgstr "Розподіли"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:78
+msgid "last synchronized date not specified"
+msgstr "дату останньої синхронізації не вказано"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:185
+msgid "No work reportlines are found for order: \"{0}\""
+msgstr "Рядки табелю не знайдено для проєкту: \"{0}\""
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:160
+msgid "timesheet template name is already being used"
+msgstr "назва шаблону табелю вже використовується"
+
+#: org/libreplan/web/common/ConfigurationController.java:843
+msgid "Code sequence is already in use and cannot be updated"
+msgstr "Послідовність коду вже використовується і не може бути оновлена"
+
+#: org/libreplan/web/advance/AdvanceTypeCRUDController.java:96
+msgid ""
+"Value is not valid, the default max value must be greater than the precision "
+"value "
+msgstr ""
+"Значення недійсне, максимальне значення за замовчуванням повинно бути більше "
+"значення точності"
+
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:52
+msgid "Criterion requirement"
+msgstr "Вимога критерію"
+
+#: libreplan-webapp/src/main/webapp/advance/_editAdvanceTypes.zul:38
+msgid "Unit name"
+msgstr "Назва одиниці"
+
+#: libreplan-business/src/main/java/org/libreplan/business/labels/entities/LabelType.java:108
+msgid "label names must be unique inside a label type"
+msgstr "назви міток повинні бути унікальними в межах типу мітки"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:173
+msgid "Task should finish job"
+msgstr "Завдання, яке повинно бути завершено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/TaskQualityFormItem.java:100
+msgid "passed not specified"
+msgstr "параметр пройдено не вказано"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:193
+msgid "Percentage of estimated budget in money / money spent"
+msgstr "Відсоток оціночного бюджету в грошах / витрачені кошти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:93
+msgid "prefix not specified"
+msgstr "префікс не вказано"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:21
+msgid "LibrePlan: Materials"
+msgstr "LibrePlan: Матеріали"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:125
+msgid "Planning view modes on"
+msgstr "Режими перегляду планування увімкнено"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:886
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:33
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:244
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:130
+msgid "Hours type"
+msgstr "Тип годин"
+
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:669
+#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:837
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:23
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:34
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:159
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:49
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:146
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:217
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:97
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:134
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:178
+msgid "Task"
+msgstr "Завдання"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:35
+msgid "User settings"
+msgstr "Налаштування користувача"
+
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:226
+msgid "percentage must be unique"
+msgstr "відсоток повинен бути унікальним"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelSubcontract.zul:100
+msgid "New delivery date"
+msgstr "Нова дата доставки"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:29
+msgid "Report structure"
+msgstr "Структура звіту"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:198
+msgid "Only one sequence per entity can be active at the same time."
+msgstr "Тільки одна послідовність на сутність може бути активною одночасно."
+
+#: org/libreplan/web/limitingresources/ManualAllocationController.java:509
+msgid "END"
+msgstr "КІНЕЦЬ"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:439
+msgid "Code cannot be empty."
+msgstr "Код не може бути порожнім."
+
+#: libreplan-webapp/src/main/webapp/common/eventError.zul:58
+#: libreplan-webapp/src/main/webapp/common/error.zul:62
+msgid "Exit session"
+msgstr "Завершити сеанс"
+
+#: org/libreplan/web/resources/worker/WorkRelationshipsController.java:159
+msgid ""
+"Could not save time period. Time period overlaps with another non-compatible "
+"time period"
+msgstr ""
+"Не вдалося зберегти часовий період. Часовий період перетинається з іншим "
+"несумісним часовим періодом"
+
+#: org/libreplan/web/scenarios/ScenarioCRUDController.java:232
+msgid "Scenarios"
+msgstr "Сценарії"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:126
+msgid "Assign selected items"
+msgstr "Призначити вибрані елементи"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:29
+msgid "Quality form"
+msgstr "Форма якості"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:136
+msgid "Current selection"
+msgstr "Поточний вибір"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:764
+msgid "Changes applied"
+msgstr "Зміни застосовано"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:119
+msgid "Tasks input buffer"
+msgstr "Буфер введення завдань"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:245
+msgid "Budgeted Cost Work Scheduled"
+msgstr "Бюджетна вартість запланованих робіт"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:310
+msgid "Last value"
+msgstr "Останнє значення"
+
+#: org/libreplan/web/planner/reassign/ReassignCommand.java:167
+msgid "Done {0} of {1}"
+msgstr "Виконано {0} з {1}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialCategory.java:242
+msgid "There are repeated material category codes"
+msgstr "Є повторювані коди категорій матеріалів"
+
+#: org/libreplan/web/templates/OrderTemplatesModel.java:298
+#: org/libreplan/web/workreports/WorkReportTypeModel.java:408
+msgid "name cannot be empty"
+msgstr "назва не може бути порожньою"
+
+#: org/libreplan/web/orders/CriterionRequirementWrapper.java:216
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:113
+msgid "Invalidate"
+msgstr "Анулювати"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:251
+msgid "VAC"
+msgstr "VAC"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:158
+msgid "Period"
+msgstr "Період"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:408
+msgid "criterion codes must be unique inside a criterion type"
+msgstr "коди критеріїв повинні бути унікальними в межах типу критерію"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:163
+msgid "Association with profiles"
+msgstr "Асоціація з профілями"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:78
+msgid "Inherited exception"
+msgstr "Успадковане виключення"
+
+#: libreplan-webapp/src/main/webapp/users/users.zul:23
+msgid "LibrePlan: User Accounts"
+msgstr "LibrePlan: Облікові записи користувачів"
+
+#: org/libreplan/web/common/ConfigurationController.java:479
+msgid "Cannot connect"
+msgstr "Неможливо підключитися"
+
+#: libreplan-business/src/main/java/org/libreplan/business/advance/entities/AdvanceType.java:274
+msgid "default maximum value must be greater than precision value"
+msgstr ""
+"максимальне значення за замовчуванням повинно бути більше значення точності"
+
+#: org/libreplan/web/common/ConfigurationController.java:833
+msgid "{0} sequences"
+msgstr "{0} послідовностей"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelLimitingResourceAllocation.zul:63
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:72
+msgid "Advanced search"
+msgstr "Розширений пошук"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:344
+#: org/libreplan/web/common/Util.java:687
+msgid "Remove"
+msgstr "Видалити"
+
+#: libreplan-webapp/src/main/webapp/common/accessForbidden.zul:20
+msgid "LibrePlan: Access Forbidden"
+msgstr "LibrePlan: Доступ заборонено"
+
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:30
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:115
+msgid "Severity"
+msgstr "Серйозність"
+
+#: org/libreplan/web/common/components/finders/UserBandboxFinder.java:46
+msgid "Full name"
+msgstr "Повне ім'я"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_taskInformation.zul:47
+msgid "Recommended allocation"
+msgstr "Рекомендований розподіл"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:205
+msgid "The browser you are using"
+msgstr "Браузер, який ви використовуєте"
+
+#: org/libreplan/web/orders/criterionrequirements/AssignedCriterionRequirementController.java:259
+msgid ""
+"Are you sure of changing the resource type? You will lose the criteria with "
+"different resource type."
+msgstr ""
+"Ви впевнені, що хочете змінити тип ресурсу? Ви втратите критерії з іншим "
+"типом ресурсу."
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:76
+msgid "Extended view"
+msgstr "Розширений вигляд"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:378
+#: org/libreplan/web/planner/order/OrderPlanningModel.java:1027
+msgid "Unsaved changes will be lost. Are you sure?"
+msgstr "Незбережені зміни будуть втрачені. Ви впевнені?"
+
+#: org/libreplan/web/dashboard/DashboardController.java:239
+#: org/libreplan/web/dashboard/DashboardController.java:268
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:35
+msgid "Number of tasks"
+msgstr "Кількість завдань"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:69
+msgid "Move selected task up"
+msgstr "Перемістити вибране завдання вгору"
+
+#: org/libreplan/web/resources/machine/MachineConfigurationController.java:206
+msgid "End date is not valid, the date field can not be blank"
+msgstr "Дата завершення недійсна, поле дати не може бути порожнім"
+
+#: org/libreplan/importers/CalendarImporterMPXJ.java:340
+msgid "Calendar name already in use"
+msgstr "Назва календаря вже використовується"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:38
+msgid "Work budgeted"
+msgstr "Заплановані роботи"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:89
+msgid "Username of user"
+msgstr "Ім'я користувача"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:371
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:817
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:53
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:82
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:103
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:31
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:83
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:28
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:51
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:163
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:89
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:136
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:203
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:104
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:73
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:181
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:43
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:43
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:43
+#: libreplan-webapp/src/main/webapp/planner/order.zul:106
+#: libreplan-webapp/src/main/webapp/planner/stretches_function.zul:53
+msgid "Date"
+msgstr "Дата"
+
+#: org/libreplan/web/importers/ProjectImportController.java:105
+msgid ": Calendar import successfully!"
+msgstr ": Календар успішно імпортовано!"
+
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:38
+msgid ""
+"Password cannot be managed for LDAP users because LDAP authentication is "
+"enabled."
+msgstr ""
+"Паролем не можна керувати для користувачів LDAP, оскільки увімкнено "
+"автентифікацію LDAP."
+
+#: org/libreplan/web/common/ConfigurationController.java:384
+msgid "Cannot connet to Tim server"
+msgstr "Не вдається підключитися до сервера Tim"
+
+#: org/libreplan/web/common/BaseCRUDController.java:313
+msgid "{0} \"{1}\" deleted"
+msgstr "{0} \"{1}\" видалено"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1022
+msgid "Hours Group at {0}"
+msgstr "Група годин у {0}"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:252
+msgid "Variance At Completion"
+msgstr "Відхилення при завершенні"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1575
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1580
+msgid "please, select a timesheet template type"
+msgstr "будь ласка, виберіть тип шаблону табелю"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:453
+#: org/libreplan/web/common/BaseCRUDController.java:131
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1023
+msgid "Create {0}: {1}"
+msgstr "Створити {0}: {1}"
+
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:32
+msgid "Synchronization of timesheets was successful"
+msgstr "Синхронізація табелів пройшла успішно"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:132
+msgid "Enable/Disable"
+msgstr "Увімкнути/Вимкнути"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:1636
+msgid "Please set a date"
+msgstr "Будь ласка, встановіть дату"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:377
+msgid ""
+"Default calendar cannot be removed. Please, change the default calendar in "
+"the Main Settings window before."
+msgstr ""
+"Календар за замовчуванням не можна видалити. Будь ласка, спочатку змініть "
+"календар за замовчуванням у вікні Основних налаштувань."
+
+#: libreplan-webapp/src/main/webapp/orders/_timImpExpInfo.zul:24
+msgid "was successful"
+msgstr "пройшло успішно"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:154
+msgid "Projects view filtering"
+msgstr "Фільтрація перегляду проєктів"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:81
+msgid "cron expression not specified"
+msgstr "cron-вираз не вказано"
+
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:88
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:29
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:82
+msgid "Disabled"
+msgstr "Вимкнено"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:254
+msgid "Cost Performance Index"
+msgstr "Індекс ефективності витрат"
+
+#: org/libreplan/web/costcategories/CostCategoryCRUDController.java:147
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:472
+msgid ""
+"Hours types are empty. Please, create some hours types before proceeding"
+msgstr "Типи годин порожні. Будь ласка, створіть типи годин перед продовженням"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:62
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:72
+msgid "Communication Date"
+msgstr "Дата повідомлення"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:97
+msgid "Latest date"
+msgstr "Найпізніша дата"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:34
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:83
+msgid "Standard Effort"
+msgstr "Стандартні трудовитрати"
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1626
+msgid "Assignment function will be changed. Are you sure?"
+msgstr "Функцію призначення буде змінено. Ви впевнені?"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/virtualWorkers.zul:22
+msgid "LibrePlan: Virtual Worker Groups"
+msgstr "LibrePlan: Групи віртуальних працівників"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:277
+msgid "Medium"
+msgstr "Середній"
+
+#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:133
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:318
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:177
+#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:139
+#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:179
+msgid "Label has already been added."
+msgstr "Мітку вже додано."
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:973
+msgid "Delete bound user"
+msgstr "Видалити прив'язаного користувача"
+
+#: libreplan-webapp/src/main/webapp/resources/worker/worker.zul:22
+msgid "LibrePlan: Workers"
+msgstr "LibrePlan: Працівники"
+
+#: org/libreplan/web/common/CustomMenuController.java:307
+msgid "Queue-based Resources"
+msgstr "Ресурси на основі черги"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:26
+msgid "Filter quality forms by"
+msgstr "Фільтрувати форми якості за"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:139
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:156
+msgid "Base calendar \"{0}\" saved"
+msgstr "Базовий календар \"{0}\" збережено"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:117
+msgid "Sum of expenses imputed in children tasks"
+msgstr "Сума витрат, віднесених на дочірні завдання"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:76
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:85
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:182
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:193
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:67
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:111
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:54
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:63
+msgid "Budget"
+msgstr "Бюджет"
+
+#: org/libreplan/web/users/UserCRUDController.java:98
+#: org/libreplan/web/users/UserCRUDController.java:99
+#: org/libreplan/web/users/UserCRUDController.java:399
+msgid "Yes"
+msgstr "Так"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1093
+msgid "This progress type cannot cannot be removed"
+msgstr "Цей тип прогресу не можна видалити"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:115
+msgid "Allowed Special Characters"
+msgstr "Дозволені спеціальні символи"
+
+#: org/libreplan/web/users/settings/SettingsController.java:182
+msgid "Resources load since should be lower than resources load to"
+msgstr ""
+"Завантаження ресурсів з повинно бути меншим за завантаження ресурсів до"
+
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:327
+msgid "Create copy"
+msgstr "Створити копію"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:1270
+msgid "End date can only be deleted in the last activation"
+msgstr "Дату завершення можна видалити лише в останній активації"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:36
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:93
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:58
+#: libreplan-webapp/src/main/webapp/resources/_costCategoryAssignment.zul:40
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:68
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:122
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:55
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:102
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:53
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:100
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:44
+msgid "Start date"
+msgstr "Дата початку"
+
+#: libreplan-webapp/src/main/webapp/labels/labelTypes.zul:21
+msgid "LibrePlan: Labels"
+msgstr "LibrePlan: Мітки"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:46
+msgid "Connectors"
+msgstr "Конектори"
+
+#: org/libreplan/importers/ImportRosterFromTim.java:182
+msgid "No valid response for department \"{0}\""
+msgstr "Немає дійсної відповіді для відділу \"{0}\""
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:499
+msgid "LDAP Roles (separated by ;)"
+msgstr "Ролі LDAP (розділені ;)"
+
+#: org/libreplan/web/users/UserCRUDController.java:503
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1147
+#: org/libreplan/web/resources/machine/MachineCRUDController.java:617
+msgid "left"
+msgstr "залишилось"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:16
+msgid "ARCHIVED"
+msgstr "АРХІВОВАНО"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:84
+msgid "Application settings"
+msgstr "Налаштування застосунку"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:56
+msgid "Quality form type"
+msgstr "Тип форми якості"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1049
+msgid ""
+"You can not remove the project \"{0}\" because it has time tracked at some "
+"of its tasks"
+msgstr ""
+"Ви не можете видалити проєкт \"{0}\", оскільки він має відстежений час у "
+"деяких завданнях"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:557
+msgid "Exception: {0} (Inh)"
+msgstr "Виняток: {0} (Усп.)"
+
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:481
+msgid "Normal resource assignment"
+msgstr "Звичайне призначення ресурсу"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementHours.zul:55
+msgid "Sum of direct imputed hours"
+msgstr "Сума прямих віднесених годин"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityForm.java:210
+msgid "Quality form item name must be unique"
+msgstr "Назва елемента форми якості має бути унікальною"
+
+#: org/libreplan/web/planner/milestone/DeleteMilestoneCommand.java:59
+msgid "Delete Milestone"
+msgstr "Видалити віху"
+
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:120
 msgid "Order \"{0}\" not found. Order probalbly not synchronized"
-msgstr ""
+msgstr "Проєкт \"{0}\" не знайдено. Проєкт, ймовірно, не синхронізовано"
 
-#: org/libreplan/web/common/CustomMenuController.java:505
-#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:39
-msgid "Materials Needed At Date"
-msgstr ""
+#: org/libreplan/web/common/CustomMenuController.java:395
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:177
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:121
+msgid "Timesheets"
+msgstr "Табелі"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:35
-msgid "PRE-SALES"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:21
+msgid "LibrePlan: Email Templates"
+msgstr "LibrePlan: Шаблони електронної пошти"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:36
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:113
+msgid "Select template"
+msgstr "Вибрати шаблон"
+
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:44
+msgid "Details"
+msgstr "Деталі"
+
+#: org/libreplan/web/workreports/WorkReportQueryController.java:285
+msgid "Task not found"
+msgstr "Завдання не знайдено"
+
+#: org/libreplan/web/planner/order/SubcontractController.java:154
+msgid "It already exists a deliver date with the same date. "
+msgstr "Дата постачання з такою ж датою вже існує. "
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:32
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:38
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractedTasks.zul:53
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:118
+msgid "Task name"
+msgstr "Назва завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:517
+msgid "last criterion sequence code not specified"
+msgstr "код останньої послідовності критерію не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/IntegrationEntity.java:47
+msgid "code not specified"
+msgstr "код не вказано"
+
+#: libreplan-webapp/src/main/webapp/myaccount/_expensesArea.zul:41
+#: libreplan-webapp/src/main/webapp/expensesheet/expenseSheet.zul:37
+msgid "New expense sheet"
+msgstr "Новий аркуш витрат"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:437
+#: org/libreplan/web/logs/RiskLogCRUDController.java:417
+msgid "please select an author"
+msgstr "будь ласка, виберіть автора"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:43
+msgid "Main preferences"
+msgstr "Основні налаштування"
+
+#: org/libreplan/web/dashboard/GlobalProgressChart.java:55
+#: libreplan-webapp/src/main/webapp/resources/_criterions.zul:56
+msgid "Current"
+msgstr "Поточний"
+
+#: libreplan-webapp/src/main/webapp/planner/montecarlo_function.zul:38
+msgid "MonteCarlo chart"
+msgstr "Діаграма Монте-Карло"
+
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:44
+msgid "Select source"
+msgstr "Вибрати джерело"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:32
+msgid "No files"
+msgstr "Немає файлів"
+
+#: org/libreplan/web/orders/OrderModel.java:753
+#: org/libreplan/web/planner/TaskElementAdapter.java:852
+#: libreplan-webapp/src/main/webapp/dashboard/_costStatus.zul:38
+msgid "Hours invested"
+msgstr "Витрачені години"
+
+#: org/libreplan/web/resources/criterion/CriterionAdminController.java:200
+msgid "Criterion Type"
+msgstr "Тип критерію"
+
+#: org/libreplan/web/materials/MaterialsController.java:493
+msgid "Cannot delete that material because it is assigned to a project."
+msgstr "Не вдається видалити цей матеріал, оскільки він призначений проєкту."
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:217
+msgid "No response or exception in response"
+msgstr "Немає відповіді або виняток у відповіді"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:345
+msgid "Host"
+msgstr "Хост"
+
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:30
+msgid "Associated user"
+msgstr "Пов'язаний користувач"
+
+#: org/libreplan/web/planner/tabs/MonteCarloTabCreator.java:51
+#: org/libreplan/web/planner/tabs/MonteCarloTabCreator.java:159
+msgid "MonteCarlo Method"
+msgstr "Метод Монте-Карло"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:444
+msgid "Forward"
+msgstr "Вперед"
+
+#: org/libreplan/web/scenarios/ScenarioModel.java:125
+msgid "You cannot remove the current scenario"
+msgstr "Ви не можете видалити поточний сценарій"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:328
+msgid ""
+"Error saving the project\n"
+"{0}"
+msgstr ""
+"Помилка збереження проєкту\n"
+"{0}"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:282
+msgid "Summary"
+msgstr "Підсумок"
+
+#: org/libreplan/web/scenarios/TransferOrdersModel.java:153
+msgid "Source and destination scenarios should be different"
+msgstr "Сценарії джерела та призначення мають бути різними"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Worker.java:166
+msgid "ID already used. It has to be be unique"
+msgstr "ID вже використовується. Він має бути унікальним"
+
+#: org/libreplan/web/common/CustomMenuController.java:504
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:39
+msgid "Hours Worked Per Resource"
+msgstr "Відпрацьовані години за ресурсом"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:26
+msgid "Upload"
+msgstr "Завантажити"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:166
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:89
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:175
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:180
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:197
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:222
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:237
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:187
+msgid "if the report is not opened automatically or use save as..."
+msgstr "якщо звіт не відкрився автоматично, або скористайтеся «Зберегти як...»"
+
+#: libreplan-webapp/src/main/webapp/limitingresources/manualAllocation.zul:100
+msgid "Select start date"
+msgstr "Вибрати дату початку"
+
+#: libreplan-webapp/src/main/webapp/planner/print_configuration.zul:35
+msgid "Expand taskgroups"
+msgstr "Розгорнути групи завдань"
+
+#: libreplan-webapp/src/main/webapp/common/layout/timeout.zul:29
+msgid "Back to log in"
+msgstr "Повернутися до входу"
+
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:132
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:511
+msgid "Connection values of JIRA connector are invalid"
+msgstr "Значення підключення конектора JIRA недійсні"
+
+#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:145
+#: org/libreplan/web/calendars/BaseCalendarCRUDController.java:415
+#: org/libreplan/web/users/ProfileCRUDController.java:158
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:339
+#: org/libreplan/web/costcategories/TypeOfWorkHoursCRUDController.java:101
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:903
+#: org/libreplan/web/planner/taskedition/AdvancedAllocationTaskController.java:72
+msgid "Warning"
+msgstr "Попередження"
+
+#: libreplan-webapp/src/main/webapp/resources/search/allocation_selector.zul:129
+msgid "Assignment Type"
+msgstr "Тип призначення"
+
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:44
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:46
+msgid "Refresh"
+msgstr "Оновити"
+
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:126
+msgid "Complementary text fields"
+msgstr "Додаткові текстові поля"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1220
+msgid ". Already registered: {0} hours"
+msgstr ". Вже зареєстровано: {0} годин"
+
+#: org/libreplan/web/tree/TreeComponent.java:66
+msgid "Scheduling state"
+msgstr "Стан планування"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:23
+msgid "LibrePlan: Main Settings"
+msgstr "LibrePlan: Основні налаштування"
+
+#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:37
+msgid "Task code"
+msgstr "Код завдання"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:38
+msgid "Timesheets List"
+msgstr "Список табелів"
+
+#: org/libreplan/web/common/JobSchedulerModel.java:157
+msgid "Milestone reached job"
+msgstr "Завдання досягнення віхи"
+
+#: libreplan-webapp/src/main/webapp/common/concurrentModification.zul:30
+msgid ""
+"Another user has modified the same data, so the operation cannot be safely "
+"completed."
+msgstr ""
+"Інший користувач змінив ті самі дані, тому операцію неможливо безпечно "
+"завершити."
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:42
+msgid "Load due to other assignments"
+msgstr "Завантаження через інші призначення"
+
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:74
+msgid "Statistics log"
+msgstr "Журнал статистики"
+
+#: org/libreplan/web/reports/ProjectStatusReportController.java:114
+msgid "You should filter the report by project, labels or criteria"
+msgstr "Ви повинні фільтрувати звіт за проєктом, мітками або критеріями"
+
+#: org/libreplan/web/orders/OrderElementTreeController.java:785
+msgid ""
+"You cannot remove the task \"{0}\" because it has work reported on it or any "
+"of its children"
+msgstr ""
+"Ви не можете видалити завдання \"{0}\", оскільки воно має звітовану роботу "
+"на ньому або на будь-якому з його дочірніх завдань"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractedTaskData.java:124
+msgid "external company not specified"
+msgstr "зовнішню компанію не вказано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReport.java:455
+msgid ""
+"only one timesheet line per day and task is allowed in personal timesheets"
+msgstr ""
+"лише один рядок табелю на день та завдання дозволено в особистих табелях"
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/EntitySequence.java:101
+msgid "last value not specified"
+msgstr "останнє значення не вказано"
+
+#: org/libreplan/web/common/components/finders/ExternalCompanyBandboxFinder.java:50
+#: libreplan-webapp/src/main/webapp/resources/worker/_edition.zul:88
+#: libreplan-webapp/src/main/webapp/resources/worker/_list.zul:37
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:29
+msgid "ID"
+msgstr "ID"
+
+#: libreplan-webapp/src/main/webapp/common/layout/login.zul:181
+msgid "We don’t show advertisements or sell your data."
+msgstr "Ми не показуємо рекламу та не продаємо ваші дані."
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:45
+msgid "Pessimistic"
+msgstr "Песимістичний"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:280
+msgid "Valid until"
+msgstr "Дійсний до"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/IssueLog.java:104
+msgid "date raised is not specified"
+msgstr "дату виникнення не вказано"
+
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:74
+msgid "Quality form items list"
+msgstr "Список елементів форми якості"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Machine.java:97
+msgid "machine name not specified"
+msgstr "назву машини не вказано"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1166
+msgid "All progress types have already been assigned."
+msgstr "Усі типи прогресу вже призначено."
+
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:135
+msgid "No worklogs found for \"{0}\" key"
+msgstr "Журнали роботи для ключа \"{0}\" не знайдено"
+
+#: org/libreplan/web/tree/TreeController.java:1038
+msgid "Disabled because of it contains more than one hours group"
+msgstr "Вимкнено, оскільки містить більше однієї групи годин"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:244
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:151
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:192
+msgid "Day of week"
+msgstr "День тижня"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:44
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:68
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_listTypesOfWorkHours.zul:30
+#: libreplan-webapp/src/main/webapp/users/_listUsers.zul:34
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:156
+#: libreplan-webapp/src/main/webapp/users/_editUser.zul:177
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:61
+#: libreplan-webapp/src/main/webapp/profiles/_listProfiles.zul:28
+#: libreplan-webapp/src/main/webapp/costcategories/_listCostCategories.zul:30
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:79
+msgid "Actions"
+msgstr "Дії"
+
+#: libreplan-webapp/src/main/webapp/planner/advance_allocation.zul:35
+msgid "No Allocations have been done"
+msgstr "Розподілів не здійснено"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:513
+msgid "Select connector"
+msgstr "Вибрати конектор"
+
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:21
+msgid "LibrePlan: Project Costs"
+msgstr "LibrePlan: Витрати проєкту"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:513
+msgid ""
+"Deadline cannot be empty because there is a task with constraint \"as late "
+"as possible\""
+msgstr ""
+"Кінцевий термін не може бути порожнім, оскільки є завдання з обмеженням "
+"\"якомога пізніше\""
+
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:62
+msgid "Add new worker assignment"
+msgstr "Додати нове призначення працівника"
+
+#: org/libreplan/web/common/CustomMenuController.java:349
+#: libreplan-webapp/src/main/webapp/orders/imports/projectImport.zul:52
+msgid "Calendars"
+msgstr "Календарі"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionType.java:163
+#: libreplan-business/src/main/java/org/libreplan/business/scenarios/entities/Scenario.java:149
+msgid "name is already used"
+msgstr "назва вже використовується"
+
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
+#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
+#: org/libreplan/web/common/components/finders/OrderElementFilterEnum.java:36
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:785
+msgid "Label"
+msgstr "Мітка"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:322
+msgid "New end date for the customer"
+msgstr "Нова дата завершення для замовника"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:243
+msgid "Timesheet lines"
+msgstr "Рядки табелю"
+
+#: libreplan-webapp/src/main/webapp/subcontract/subcontractorCommunications.zul:60
+msgid "Subcontracted task"
+msgstr "Завдання субпідрядника"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:23
+msgid "LibrePlan: Timesheet Lines List"
+msgstr "LibrePlan: Список рядків табелю"
+
+#: org/libreplan/web/workreports/WorkReportCRUDController.java:683
+msgid "Create Timesheet"
+msgstr "Створити табель"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:225
+msgid "Expense sheets"
+msgstr "Аркуші витрат"
+
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:35
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:173
+msgid "Overtime Effort"
+msgstr "Понаднормові трудовитрати"
+
+#: org/libreplan/web/common/CustomMenuController.java:343
+msgid "Virtual Workers"
+msgstr "Віртуальні працівники"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:184
+msgid "Criterion filter"
+msgstr "Фільтр критеріїв"
+
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/ExternalCompany.java:148
+msgid "company name must be unique. Company name already used"
+msgstr ""
+"назва компанії має бути унікальною. Назва компанії вже використовується"
+
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:134
+msgid "Planning Configuration"
+msgstr "Конфігурація планування"
+
+#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:113
+#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:131
+#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:151
+#: org/libreplan/web/planner/tabs/DashboardTabCreator.java:160
+msgid "Dashboard"
+msgstr "Інформаційна панель"
+
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:45
+msgid "From date"
+msgstr "Від дати"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:741
+msgid "Create Virtual Workers Group"
+msgstr "Створити групу віртуальних працівників"
+
+#: org/libreplan/web/common/components/TwoWaySelector.java:68
+msgid "Assigned"
+msgstr "Призначено"
+
+#: org/libreplan/web/resourceload/ResourceLoadController.java:455
+msgid "From"
+msgstr "Від"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:479
+msgid "The code cannot be empty and it must be unique."
+msgstr "Код не може бути порожнім і має бути унікальним."
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:51
+msgid "Average of worked hours in finished applications"
+msgstr "Середня кількість відпрацьованих годин у завершених застосунках"
+
+#: org/libreplan/web/planner/allocation/stretches/StretchesFunctionModel.java:278
+msgid "Stretch date must not be before task start date: "
+msgstr "Дата розтягнення не повинна бути раніше дати початку завдання: "
+
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1620
+msgid "Task contains consolidated progress. Cannot apply sigmoid function."
+msgstr ""
+"Завдання містить консолідований прогрес. Неможливо застосувати сигмоїдну "
+"функцію."
+
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:107
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:116
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:129
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:157
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:169
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:120
+msgid "Filter by criteria"
+msgstr "Фільтрувати за критеріями"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:27
+msgid "Overload due to other assignments"
+msgstr "Перевантаження через інші призначення"
+
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartOrder.zul:29
+msgid "External overload"
+msgstr "Зовнішнє перевантаження"
+
+#: libreplan-webapp/src/main/webapp/myaccount/settings.zul:135
+msgid "Show resources"
+msgstr "Показати ресурси"
+
+#: org/libreplan/web/expensesheet/ExpenseSheetCRUDController.java:231
+msgid "expense line of the "
+msgstr "рядок витрат від "
+
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/JobSchedulerConfiguration.java:120
+msgid "job group and name are already being used"
+msgstr "група та назва завдання вже використовуються"
+
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:33
+msgid "Assigned To"
+msgstr "Призначено для"
+
+#: org/libreplan/web/logs/IssueLogCRUDController.java:276
+msgid "Low"
+msgstr "Низький"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:57
+msgid "Calculated"
+msgstr "Обчислено"
+
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_allocationConfiguration.zul:41
+msgid "Planned workable days"
+msgstr "Заплановані робочі дні"
+
+#: org/libreplan/web/orders/OrderCRUDController.java:1679
+#: org/libreplan/web/planner/order/SubcontractController.java:139
+msgid "You must select a valid date. "
+msgstr "Ви повинні вибрати дійсну дату. "
+
+#: org/libreplan/web/common/CustomMenuController.java:560
+msgid "Reports"
+msgstr "Звіти"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:139
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:190
+msgid "Day of month"
+msgstr "День місяця"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1136
+msgid ""
+"resource cost category assignments codes must be unique inside a resource"
+msgstr ""
+"коди призначень категорій витрат ресурсу мають бути унікальними всередині "
+"ресурсу"
+
+#: org/libreplan/web/reports/WorkingProgressPerTaskController.java:160
+#: org/libreplan/web/reports/HoursWorkedPerWorkerController.java:342
+#: org/libreplan/web/reports/OrderCostsPerResourceController.java:204
+#: org/libreplan/web/reports/CompletedEstimatedHoursPerTaskController.java:166
+#: org/libreplan/web/reports/WorkingArrangementsPerOrderController.java:206
+msgid "please, select a Criterion"
+msgstr "будь ласка, виберіть критерій"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:55
+msgid "Maximum/minimum of estimated hours"
+msgstr "Максимум/мінімум розрахункових годин"
+
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:165
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul:88
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:174
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:179
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:196
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:221
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:236
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:166
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:186
+msgid "direct link"
+msgstr "пряме посилання"
+
+#: org/libreplan/web/orders/materials/AssignedMaterialsController.java:450
+msgid "Do you want to split the material assignment {0}?"
+msgstr "Бажаєте розділити призначення матеріалу {0}?"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/valueobjects/DescriptionField.java:80
+msgid "length less than 1"
+msgstr "довжина менше 1"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/Task.java:193
+msgid "element associated to a task must be not empty"
+msgstr "елемент, пов'язаний із завданням, не може бути порожнім"
+
+#: libreplan-webapp/src/main/webapp/common/_editJobScheduling.zul:146
+msgid "or names"
+msgstr "або імена"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementTaskQualityForms.zul:50
+msgid "Task quality form name"
+msgstr "Назва форми якості завдання"
+
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:167
+msgid "if the report is not opened automatically"
+msgstr "якщо звіт не відкрився автоматично"
+
+#: org/libreplan/web/common/components/finders/TaskGroupFilterEnum.java:30
+#: org/libreplan/web/common/components/finders/ResourceFilterEnum.java:29
+#: org/libreplan/web/common/components/finders/ResourceFilterEnumByResourceAndCriterion.java:31
+#: org/libreplan/web/common/components/finders/OrderFilterEnum.java:30
+#: org/libreplan/web/common/components/finders/TaskElementFilterEnum.java:34
+#: org/libreplan/web/common/components/finders/OrderElementFilterEnum.java:36
+#: org/libreplan/web/common/components/finders/ResourceAllocationFilterEnum.java:30
+msgid "Criterion"
+msgstr "Критерій"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:42
+msgid "Timesheet data"
+msgstr "Дані табелю"
+
+#: org/libreplan/web/orders/OrdersTreeComponent.java:105
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:149
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:70
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:33
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:53
+#: libreplan-webapp/src/main/webapp/logs/_listIssueLog.zul:34
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:141
+#: libreplan-webapp/src/main/webapp/subcontract/customerCommunications.zul:59
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:47
+msgid "Deadline"
+msgstr "Кінцевий термін"
+
+#: libreplan-webapp/src/main/webapp/templates/_historicalAssignment.zul:51
+msgid "View"
+msgstr "Перегляд"
+
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:9
 msgid "OFFERED"
-msgstr ""
+msgstr "ЗАПРОПОНОВАНО"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:37
-msgid "OUTSOURCED"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/dashboard/_pipeline.zul:8
+msgid "PRE-SALES"
+msgstr "ПЕРЕДПРОДАЖ"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:38
-msgid "ACCEPTED"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_synchronizationInfo.zul:20
+msgid "LibrePlan: Synchronization info"
+msgstr "LibrePlan: Інформація про синхронізацію"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:39
-msgid "STARTED"
-msgstr ""
+#: org/libreplan/web/logs/IssueLogCRUDController.java:270
+msgid "Major"
+msgstr "Значний"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:40
-msgid "ON HOLD"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Resource.java:1130
+msgid "criterion satisfaction codes must be unique inside a resource"
+msgstr "коди задоволення критеріїв мають бути унікальними всередині ресурсу"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:41
-msgid "FINISHED"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/templates/_historicalStatistics.zul:30
+msgid "Statistics list "
+msgstr "Список статистики "
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:42
-msgid "CANCELLED"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_jiraSyncInfo.zul:20
+msgid "LibrePlan: JIRA synchronization info"
+msgstr "LibrePlan: Інформація про синхронізацію JIRA"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderStatusEnum.java:43
-msgid "STORED"
-msgstr ""
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:784
+msgid "The max value must be greater than 0"
+msgstr "Максимальне значення має бути більше 0"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:366
-msgid "Fully scheduled"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementCriterionRequirements.zul:184
+msgid "Add new hours group"
+msgstr "Додати нову групу годин"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:368
-msgid "Partially scheduled"
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:51
+#: libreplan-webapp/src/main/webapp/orders/_orderElementTreeFilter.zul:41
+msgid "Apply filtering to tasks satisfying required criteria"
 msgstr ""
+"Застосувати фільтрацію до завдань, що задовольняють обов'язкові критерії"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:370
-msgid "Unscheduled"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:66
+msgid "Next"
+msgstr "Далі"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:376
-msgid "F"
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportType.java:387
+msgid ""
+"In the lines part, index labels and fields must be unique and consecutive"
 msgstr ""
+"У частині рядків індекси міток та полів мають бути унікальними та "
+"послідовними"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:378
-msgid "P"
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/MachineWorkersConfigurationUnit.java:166
+msgid ""
+"All machine worker assignments must have a start date earlier than the end "
+"date"
 msgstr ""
+"Усі призначення працівників машин повинні мати дату початку раніше за дату "
+"завершення"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:380
-msgid "U"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/HourCost.java:86
+msgid "price cost not specified"
+msgstr "вартість ціни не вказано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/CriterionRequirementHandler.java:539
-msgid "The criterion already exists into another task"
-msgstr ""
+#: org/libreplan/web/common/JobSchedulerController.java:363
+#: org/libreplan/web/common/JobSchedulerController.java:368
+msgid "Job scheduling"
+msgstr "Планування завдань"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:769
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLineGroup.java:969
-msgid "Cannot spread two progress in the same task"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/CriterionType.java:210
+msgid "criterion type name not specified"
+msgstr "назву типу критерію не вказано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:793
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:819
-msgid "Duplicate Progress Assignment For Task"
-msgstr ""
+#: org/libreplan/web/dashboard/DashboardController.java:219
+msgid "Task Completation Lead/Lag"
+msgstr "Випередження/Відставання завершення завдання"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1145
-msgid "Quality form already exists"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/planner/_legendLoadChartCompany.zul:34
+msgid "Load 100%"
+msgstr "Завантаження 100%"
 
-#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/HoursGroup.java:205
-msgid "Total percentage should be less than 100%"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:123
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:47
+msgid "New timesheet"
+msgstr "Новий табель"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:35
-msgid "Monthly"
-msgstr ""
+#: org/libreplan/web/limitingresources/QueueComponent.java:493
+msgid "Invalid queue element"
+msgstr "Недійсний елемент черги"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:66
-msgid "Twice-monthly"
+#: org/libreplan/web/planner/tabs/MultipleTabsPlannerController.java:262
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:355
+msgid ""
+"You are about to leave the planning editing. Unsaved changes will be lost!"
 msgstr ""
+"Ви збираєтесь покинути редагування планування. Незбережені зміни будуть "
+"втрачені!"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:123
-msgid "Weekly"
-msgstr ""
+#: org/libreplan/web/orders/OrderCRUDController.java:1618
+#: org/libreplan/web/orders/ProjectDetailsController.java:169
+msgid "project name already being used"
+msgstr "назва проєкту вже використовується"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:37
-msgid "Progress with all tasks by hours"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/_personalTimesheetsArea.zul:22
+msgid "Personal timesheets"
+msgstr "Особисті табелі"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:38
-msgid "Progress with critical path tasks by hours"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:355
+msgid "Port"
+msgstr "Порт"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:39
-msgid "Progress with critical path tasks by duration"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/myaccount/changePassword.zul:54
+msgid "Password settings"
+msgstr "Налаштування пароля"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:34
-msgid "Activated"
-msgstr ""
+#: org/libreplan/web/planner/TaskElementAdapter.java:871
+msgid "Budget: {0}, Consumed: {1} ({2}%)"
+msgstr "Бюджет: {0}, Використано: {1} ({2}%)"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:35
-msgid "Server URL"
-msgstr ""
+#: org/libreplan/web/users/dashboard/PersonalTimesheetController.java:664
+#: org/libreplan/web/common/components/finders/OrderElementBandboxFinder.java:51
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:1008
+#: libreplan-webapp/src/main/webapp/orders/_orderFilter.zul:23
+#: libreplan-webapp/src/main/webapp/logs/_editRiskLog.zul:35
+#: libreplan-webapp/src/main/webapp/logs/_editIssueLog.zul:34
+#: libreplan-webapp/src/main/webapp/myaccount/_myTasksArea.zul:33
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:144
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:42
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:55
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:64
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:47
+msgid "Project"
+msgstr "Проєкт"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:40
-msgid "Number of days timesheet to Tim"
+#: org/libreplan/web/planner/taskedition/TaskPropertiesController.java:808
+msgid "You cannot email user twice with the same info"
 msgstr ""
+"Ви не можете надіслати користувачу електронний лист двічі з тією самою "
+"інформацією"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:41
-msgid "Number of days roster from Tim"
-msgstr ""
+#: libreplan-webapp/src/main/webapp/workreports/workReport.zul:72
+msgid "Date Start"
+msgstr "Дата початку"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:42
-msgid "Productivity factor"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ConnectorProperty.java:51
+msgid "property key not specified"
+msgstr "ключ властивості не вказано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:43
-msgid "Department IDs to import toster"
-msgstr ""
+#: org/libreplan/importers/JiraOrderElementSynchronizer.java:517
+#: org/libreplan/importers/JiraTimesheetSynchronizer.java:104
+msgid "Synchronization"
+msgstr "Синхронізація"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:46
-msgid "JIRA labels: comma-separated list of labels or URL"
-msgstr ""
+#: org/libreplan/web/workreports/WorkReportTypeCRUDController.java:766
+msgid "Unallocated name"
+msgstr "Нерозподілена назва"
 
-#: libreplan-business/src/main/java/org/libreplan/business/common/daos/EntitySequenceDAO.java:82
-msgid "Entity Sequence cannot be deleted. Entity Sequence already in use"
+#: libreplan-webapp/src/main/webapp/planner/order.zul:88
+#: libreplan-webapp/src/main/webapp/planner/order.zul:94
+msgid "Check consolidated progresses"
+msgstr "Перевірити консолідований прогрес"
+
+#: org/libreplan/web/orders/AssignedTaskQualityFormsToOrderElementController.java:353
+#: org/libreplan/web/tree/TreeComponent.java:51
+#: org/libreplan/web/common/components/finders/QualityFormBandboxFinder.java:50
+#: org/libreplan/web/common/components/finders/TypeOfWorkHoursBandboxFinder.java:43
+#: org/libreplan/web/common/components/finders/BaseCalendarBandboxFinder.java:46
+#: org/libreplan/web/common/components/finders/ScenarioBandboxFinder.java:46
+#: org/libreplan/web/common/components/finders/ExternalCompanyBandboxFinder.java:50
+#: org/libreplan/web/common/components/finders/LabelBandboxFinder.java:51
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:1013
+#: org/libreplan/web/planner/allocation/ResourceAllocationController.java:438
+#: libreplan-webapp/src/main/webapp/excetiondays/_listExceptionDayTypes.zul:31
+#: libreplan-webapp/src/main/webapp/excetiondays/_editExceptionDayType.zul:54
+#: libreplan-webapp/src/main/webapp/materials/materials.zul:61
+#: libreplan-webapp/src/main/webapp/unittypes/_editUnitType.zul:51
+#: libreplan-webapp/src/main/webapp/orders/_edition.zul:97
+#: libreplan-webapp/src/main/webapp/orders/_projectDetails.zul:38
+#: libreplan-webapp/src/main/webapp/orders/components/_listOrderElementMaterials.zul:120
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementFiles.zul:37
+#: libreplan-webapp/src/main/webapp/orders/_assignmentsBox.zul:28
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:29
+#: libreplan-webapp/src/main/webapp/logs/_logsFilter.zul:21
+#: libreplan-webapp/src/main/webapp/templates/_listTemplates.zul:29
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:87
+#: libreplan-webapp/src/main/webapp/templates/_assignedQualityForms.zul:49
+#: libreplan-webapp/src/main/webapp/typeofworkhours/_editTypeOfWorkHours.zul:52
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:41
+#: libreplan-webapp/src/main/webapp/calendars/_list.zul:28
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:66
+#: libreplan-webapp/src/main/webapp/scenarios/transferOrders.zul:76
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:32
+#: libreplan-webapp/src/main/webapp/scenarios/_edition.zul:52
+#: libreplan-webapp/src/main/webapp/scenarios/_list.zul:27
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:46
+#: libreplan-webapp/src/main/webapp/profiles/_editProfile.zul:41
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:531
+#: libreplan-webapp/src/main/webapp/advance/_listAdvanceTypes.zul:27
+#: libreplan-webapp/src/main/webapp/limitingresources/limitingResourcesLayout.zul:95
+#: libreplan-webapp/src/main/webapp/externalcompanies/_listExternalCompanies.zul:26
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:42
+#: libreplan-webapp/src/main/webapp/qualityforms/_editQualityForm.zul:83
+#: libreplan-webapp/src/main/webapp/qualityforms/_listQualityForm.zul:38
+#: libreplan-webapp/src/main/webapp/costcategories/_editCostCategory.zul:59
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:34
+#: libreplan-webapp/src/main/webapp/workreports/_sortFieldsAndLabels.zul:50
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:45
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:141
+#: libreplan-webapp/src/main/webapp/workreports/_editWorkReportType.zul:167
+#: libreplan-webapp/src/main/webapp/workreports/_listWorkReportTypes.zul:27
+#: libreplan-webapp/src/main/webapp/labels/_listLabelTypes.zul:26
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:42
+#: libreplan-webapp/src/main/webapp/labels/_editLabelType.zul:77
+#: libreplan-webapp/src/main/webapp/resources/worker/_listVirtualWorkers.zul:34
+#: libreplan-webapp/src/main/webapp/resources/machine/_listMachines.zul:35
+#: libreplan-webapp/src/main/webapp/resources/machine/_editMachine.zul:56
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:34
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:67
+#: libreplan-webapp/src/main/webapp/resources/machine/_machineConfigurationUnits.zul:130
+#: libreplan-webapp/src/main/webapp/resources/criterions/_criterionsTree.zul:44
+#: libreplan-webapp/src/main/webapp/resources/criterions/_edition.zul:39
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:27
+#: libreplan-webapp/src/main/webapp/resources/criterions/_workers.zul:45
+#: libreplan-webapp/src/main/webapp/resources/criterions/_list.zul:25
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:120
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:88
+#: libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul:130
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:96
+#: libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul:137
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:109
+#: libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul:153
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:95
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:137
+#: libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul:179
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:100
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:149
+#: libreplan-webapp/src/main/webapp/reports/orderCostsPerResource.zul:192
+#: libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul:98
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:100
+#: libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul:143
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelTaskProperties.zul:33
+#: libreplan-webapp/src/main/webapp/planner/taskpanels/_tabPanelNonLimitingResourceAllocation.zul:90
+#: libreplan-webapp/src/main/webapp/planner/main.zul:49
+msgid "Name"
+msgstr "Назва"
+
+#: org/libreplan/web/templates/historicalAssignment/OrderElementHistoricalAssignmentComponent.java:155
+#: org/libreplan/web/limitingresources/LimitingResourcesController.java:331
+#: org/libreplan/web/resourceload/ResourceLoadController.java:1053
+#: org/libreplan/web/resourceload/ResourceLoadController.java:1058
+#: org/libreplan/web/planner/taskedition/EditTaskController.java:374
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:347
+#: org/libreplan/web/planner/allocation/AdvancedAllocationController.java:764
+msgid "Information"
+msgstr "Інформація"
+
+#: org/libreplan/web/resources/worker/WorkerModel.java:254
+msgid "Worker must be not-null"
+msgstr "Працівник не може бути порожнім"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:247
+msgid "BCWP"
+msgstr "BCWP"
+
+#: org/libreplan/web/planner/order/SaveCommandBuilder.java:863
+msgid ""
+"Confirm creating a new project version for this scenario and derived. Are "
+"you sure?"
 msgstr ""
+"Підтвердіть створення нової версії проєкту для цього сценарію та похідних. "
+"Ви впевнені?"
+
+#: org/libreplan/importers/ExportTimesheetsToTim.java:224
+msgid "Registration response with empty refs"
+msgstr "Відповідь реєстрації з порожніми посиланнями"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:31
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:56
+msgid "Read"
+msgstr "Читання"
+
+#: org/libreplan/web/planner/TaskElementAdapter.java:1234
+msgid "Project margin: {0}% ({1})={2}"
+msgstr "Маржа проєкту: {0}% ({1})={2}"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/WorkReportLine.java:391
+msgid "fields should match with timesheet data if are shared by lines"
+msgstr "поля мають відповідати даним табелю, якщо вони спільні для рядків"
+
+#: org/libreplan/web/planner/chart/EarnedValueChartFiller.java:252
+msgid "ETC"
+msgstr "ETC"
+
+#: org/libreplan/web/calendars/BaseCalendarEditionController.java:555
+msgid "Exception: {0}"
+msgstr "Виняток: {0}"
+
+#: org/libreplan/web/common/CustomMenuController.java:518
+#: libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul:39
+msgid "Work And Progress Per Project"
+msgstr "Робота та прогрес за проєктом"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_orderElementTree.zul:84
+msgid "Delete selected task"
+msgstr "Видалити вибране завдання"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:238
+msgid "Criteria: {0}"
+msgstr "Критерії: {0}"
+
+#: libreplan-webapp/src/main/webapp/orders/_orderElementDetails.zul:71
+#: libreplan-webapp/src/main/webapp/templates/_editTemplate.zul:114
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:258
+msgid "cannot be negative or empty"
+msgstr "не може бути від'ємним або порожнім"
+
+#: org/libreplan/web/externalcompanies/ExternalCompanyCRUDController.java:175
+msgid "{0} \"{1}\" can not be deleted because of it is being used"
+msgstr "{0} \"{1}\" не можна видалити, оскільки використовується"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/Profile.java:68
+msgid "profile name not specified"
+msgstr "назву профілю не вказано"
+
+#: org/libreplan/web/users/dashboard/UserDashboardController.java:71
+msgid "Expense sheet \"{0}\" saved"
+msgstr "Аркуш витрат \"{0}\" збережено"
+
+#: libreplan-webapp/src/main/webapp/common/configuration.zul:120
+msgid "Currency"
+msgstr "Валюта"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:32
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAuthorizations.zul:57
+msgid "Write"
+msgstr "Запис"
+
+#: libreplan-webapp/src/main/webapp/workreports/workReportQuery.zul:115
+msgid "Task Code"
+msgstr "Код завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderSyncInfo.java:87
+msgid "key not specified"
+msgstr "ключ не вказано"
+
+#: libreplan-webapp/src/main/webapp/montecarlo/_montecarlo.zul:100
+msgid "Go!"
+msgstr "Вперед!"
+
+#: libreplan-webapp/src/main/webapp/logs/_listRiskLog.zul:34
+msgid "New risk score"
+msgstr "Нова оцінка ризику"
+
+#: libreplan-business/src/main/java/org/libreplan/business/costcategories/entities/CostCategory.java:281
+msgid "Two Hour Cost of the same type overlap in time"
+msgstr "Дві вартості годин одного типу перетинаються в часі"
+
+#: libreplan-webapp/src/main/webapp/subcontract/reportAdvances.zul:35
+msgid "Communications To Customers"
+msgstr "Повідомлення замовникам"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1131
+msgid ""
+"Progress measurement cannot be canged to {0}, because it is consolidated"
+msgstr ""
+"Вимірювання прогресу не можна змінити на {0}, оскільки воно консолідоване"
+
+#: org/libreplan/web/resources/search/NewAllocationSelectorController.java:701
+msgid "End filtering date cannot be empty"
+msgstr "Кінцева дата фільтрації не може бути порожньою"
+
+#: libreplan-webapp/src/main/webapp/orders/_editOrderElement.zul:39
+#: libreplan-webapp/src/main/webapp/templates/_editTemplateWindow.zul:42
+#: libreplan-webapp/src/main/webapp/planner/editTask.zul:48
+msgid "Edit task"
+msgstr "Редагувати завдання"
+
+#: org/libreplan/web/resources/worker/WorkerCRUDController.java:1104
+msgid "Confirm editing user"
+msgstr "Підтвердити редагування користувача"
+
+#: org/libreplan/web/planner/tabs/AdvancedAllocationTabCreator.java:153
+#: org/libreplan/web/planner/tabs/AdvancedAllocationTabCreator.java:238
+msgid "Advanced Allocation"
+msgstr "Розширений розподіл"
+
+#: org/libreplan/web/planner/tabs/LimitingResourcesTabCreator.java:84
+#: org/libreplan/web/planner/tabs/LimitingResourcesTabCreator.java:103
+msgid "Queue-based Resources Planning"
+msgstr "Планування ресурсів на основі черги"
+
+#: libreplan-webapp/src/main/webapp/myaccount/personalTimesheet.zul:57
+msgid "Previous"
+msgstr "Попередній"
+
+#: org/libreplan/web/limitingresources/QueueComponent.java:504
+msgid "Unassign"
+msgstr "Скасувати призначення"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:144
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:156
+msgid "Invalid Spread values. At least one value should be true"
+msgstr "Недійсні значення поширення. Принаймні одне значення має бути істинним"
+
+#: libreplan-webapp/src/main/webapp/orders/_list.zul:36
+msgid "Planned Budget"
+msgstr "Запланований бюджет"
+
+#: org/libreplan/web/orders/ManageOrderElementAdvancesController.java:1226
+msgid ""
+"Date is not valid, it must be later than the last progress reported to the "
+"customer"
+msgstr ""
+"Дата недійсна, вона має бути пізнішою за останній прогрес, повідомлений "
+"замовнику"
+
+#: libreplan-webapp/src/main/webapp/calendars/_edition.zul:139
+msgid "Work week"
+msgstr "Робочий тиждень"
+
+#: org/libreplan/web/importers/ProjectImportController.java:121
+msgid ": Import successfully!"
+msgstr ": Імпорт успішний!"
+
+#: libreplan-webapp/src/main/webapp/email/email_templates.zul:82
+msgid "Keyword"
+msgstr "Ключове слово"
+
+#: libreplan-webapp/src/main/webapp/calendars/_createNewVersion.zul:51
+msgid "Up to date"
+msgstr "Актуально"
+
+#: libreplan-webapp/src/main/webapp/resources/machine/machines.zul:22
+msgid "LibrePlan: Machines"
+msgstr "LibrePlan: Машини"
+
+#: libreplan-webapp/src/main/webapp/orders/_listOrderElementAdvances.zul:55
+#: libreplan-webapp/src/main/webapp/templates/_advances.zul:38
+msgid "Spread"
+msgstr "Поширення"
+
+#: org/libreplan/web/logs/RiskLogCRUDController.java:392
+msgid "Issue log"
+msgstr "Журнал проблем"
+
+#: org/libreplan/web/qualityforms/QualityFormCRUDController.java:155
+msgid ""
+"Deleting this item will disable the report progress option. Are you sure?"
+msgstr ""
+"Видалення цього елемента вимкне параметр звітування прогресу. Ви впевнені?"
+
+#: org/libreplan/web/templates/TemplatesTreeComponent.java:68
+msgid "Delete Template element"
+msgstr "Видалити елемент шаблону"
+
+#: libreplan-webapp/src/main/webapp/orders/components/_timOrderTimesheetSync.zul:33
+msgid "Tim last sync"
+msgstr "Остання синхронізація Tim"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:30
+msgid "red (default)"
+msgstr "червоний (за замовчуванням)"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:31
+msgid "green"
+msgstr "зелений"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:32
+msgid "blue"
+msgstr "синій"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:33
+msgid "cyan"
+msgstr "блакитний"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:34
+msgid "magenta"
+msgstr "пурпуровий"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:35
+msgid "yellow"
+msgstr "жовтий"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:36
+msgid "black"
+msgstr "чорний"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:37
+msgid "orange"
+msgstr "помаранчевий"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:38
+msgid "purple"
+msgstr "фіолетовий"
+
+#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/Capacity.java:173
+msgid "unlimited"
+msgstr "необмежено"
 
 #: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:31
 msgid "New project"
-msgstr ""
+msgstr "Новий проєкт"
 
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:31
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:32
 msgid "Progress Update"
-msgstr ""
+msgstr "Оновлення прогресу"
 
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:32
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:33
 msgid "Update Delivering Date"
-msgstr ""
+msgstr "Оновити дату постачання"
 
-#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:32
+#: libreplan-business/src/main/java/org/libreplan/business/externalcompanies/entities/CommunicationType.java:34
 msgid "End date update"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:31
-msgid "red (default)"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:32
-msgid "green"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:33
-msgid "blue"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:34
-msgid "cyan"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:35
-msgid "magenta"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:36
-msgid "yellow"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:37
-msgid "black"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:38
-msgid "orange"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/CalendarExceptionTypeColor.java:39
-msgid "purple"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/calendars/entities/Capacity.java:169
-msgid "unlimited"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceEnum.java:32
-msgid "WORKER"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceEnum.java:33
-msgid "MACHINE"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:194
-msgid "[generic all machines]"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:156
-msgid "Line"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormType.java:29
-msgid "by percentage"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormType.java:29
-msgid "by items"
-msgstr ""
+msgstr "Оновлення дати завершення"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialStatusEnum.java:32
 msgid "RECEIVED"
-msgstr ""
+msgstr "ОТРИМАНО"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialStatusEnum.java:33
 msgid "PENDING"
-msgstr ""
+msgstr "ОЧІКУЄТЬСЯ"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialStatusEnum.java:34
 msgid "ORDERED"
-msgstr ""
+msgstr "ЗАМОВЛЕНО"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialStatusEnum.java:35
 msgid "PROCESSING"
-msgstr ""
+msgstr "ОБРОБЛЯЄТЬСЯ"
 
 #: libreplan-business/src/main/java/org/libreplan/business/materials/entities/MaterialStatusEnum.java:36
 msgid "CANCELED"
-msgstr ""
+msgstr "СКАСОВАНО"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:31
-msgid "Number of assigned hours"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:752
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderLineGroup.java:972
+msgid "Cannot spread two progress in the same task"
+msgstr "Не можна поширити два прогреси на одне завдання"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:32
-msgid "Number of hours calculated by clock"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:774
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:795
+msgid "Duplicate Progress Assignment For Task"
+msgstr "Дублікат призначення прогресу для завдання"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:33
-msgid "Number of assigned hours and time"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/OrderElement.java:1104
+msgid "Quality form already exists"
+msgstr "Форма якості вже існує"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/PositionInWorkReportEnum.java:34
-msgid "heading"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:366
+msgid "Fully scheduled"
+msgstr "Повністю заплановано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/PositionInWorkReportEnum.java:34
-msgid "line"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:368
+msgid "Partially scheduled"
+msgstr "Частково заплановано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:362
-msgid "Database"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:370
+msgid "Unscheduled"
+msgstr "Не заплановано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:362
-msgid "LDAP"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:376
+msgid "F"
+msgstr "F"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorizationType.java:33
-msgid "Read authorization"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:378
+msgid "P"
+msgstr "P"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorizationType.java:34
-msgid "Write authorization"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/SchedulingState.java:380
+msgid "U"
+msgstr "U"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:37
-msgid "Web service reader"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/CriterionRequirementHandler.java:539
+msgid "The criterion already exists into another task"
+msgstr "Критерій вже існує в іншому завданні"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:38
-msgid "Web service writer"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/orders/entities/HoursGroup.java:209
+msgid "Total percentage should be less than 100%"
+msgstr "Загальний відсоток має бути менше 100%"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:39
-msgid "Web service subcontractor operations"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:35
+msgid "Monthly"
+msgstr "Щомісяця"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:41
-msgid "Read all projects"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:66
+msgid "Twice-monthly"
+msgstr "Двічі на місяць"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:42
-msgid "Edit all projects"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PersonalTimesheetsPeriodicityEnum.java:123
+msgid "Weekly"
+msgstr "Щотижня"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:43
-msgid "Create projects"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:34
+msgid "Activated"
+msgstr "Активовано"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:49
-msgid "Import projects"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:35
+msgid "Server URL"
+msgstr "URL сервера"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:76
-msgid "Hours Worked Per Resource Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:40
+msgid "Number of days timesheet to Tim"
+msgstr "Кількість днів табелю до Tim"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:77
-msgid "Total Worked Hours By Resource In A Month Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:41
+msgid "Number of days roster from Tim"
+msgstr "Кількість днів розкладу з Tim"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:78
-msgid "Work And Progress Per Project Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:42
+msgid "Productivity factor"
+msgstr "Коефіцієнт продуктивності"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:79
-msgid "Work And Progress Per Task Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:43
+msgid "Department IDs to import toster"
+msgstr "ID відділів для імпорту розкладу"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:80
-msgid "Estimated/Planned Hours Per Task Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:46
+msgid "JIRA labels: comma-separated list of labels or URL"
+msgstr "Мітки JIRA: список міток або URL, розділених комами"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:81
-msgid "Project Costs Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:55
+msgid "Protocol"
+msgstr "Протокол"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:82
-msgid "Task Scheduling Status In Project Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:58
+msgid "From address (no reply)"
+msgstr "Адреса відправника (без відповіді)"
 
-#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:83
-msgid "Materials Needed At Date Report"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:59
+msgid "Username (optional)"
+msgstr "Ім'я користувача (необов'язково)"
 
-#: libreplan-business/src/main/java/org/libreplan/business/planner/limiting/entities/LimitingResourceQueueDependency.java:170
-msgid "A queue dependency has to have an origin different from destiny"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/PredefinedConnectorProperties.java:60
+msgid "Password (optional)"
+msgstr "Пароль (необов'язково)"
 
-#: libreplan-business/src/main/java/org/libreplan/business/planner/limiting/entities/QueuePosition.java:53
-msgid "Hour should be between 0 and 23"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:37
+msgid "Progress with all tasks by hours"
+msgstr "Прогрес усіх завдань за годинами"
 
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:93
-msgid "There are no days available due to not satisfying the criteria."
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:38
+msgid "Progress with critical path tasks by hours"
+msgstr "Прогрес завдань критичного шляху за годинами"
 
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:94
-msgid ""
-"Another possibility is that the resources do not have days available due to "
-"their calendars."
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/common/entities/ProgressType.java:39
+msgid "Progress with critical path tasks by duration"
+msgstr "Прогрес завдань критичного шляху за тривалістю"
 
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:100
-msgid ""
-"There are no days available in the days marked available by the task "
-"calendar."
+#: libreplan-business/src/main/java/org/libreplan/business/common/daos/EntitySequenceDAO.java:75
+msgid "Entity Sequence cannot be deleted. Entity Sequence already in use"
 msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:101
-msgid "Maybe the criteria are not satisfied in those days."
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:173
-msgid "Resource is not available from task's start"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:178
-msgid "Resource is not available according to task's calendar"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskDeadlineViolationStatusEnum.java:35
-msgid "Deadline violated"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:410
-msgid "Stretches must sum 100%"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:76
-msgid "Flat"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:78
-msgid "Stretches"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:79
-msgid "Interpolation"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:80
-msgid "Sigmoid"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:31
-msgid "as soon as possible"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:38
-msgid "start not earlier than"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:45
-msgid "start in fixed date"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:57
-msgid "as late as possible"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:64
-msgid "finish not later than"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:29
-msgid "In progress"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:30
-msgid "Pending"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:31
-msgid "Blocked"
-msgstr ""
-
-#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:32
-msgid "Ready to start"
-msgstr ""
+"Послідовність сутності не можна видалити. Послідовність сутності вже "
+"використовується"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractState.java:32
 msgid "Pending initial send"
-msgstr ""
+msgstr "Очікує початкового надсилання"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractState.java:33
 msgid "Pending update delivering date"
-msgstr ""
+msgstr "Очікує оновлення дати постачання"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractState.java:34
 msgid "Failed sent"
-msgstr ""
+msgstr "Надсилання не вдалося"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractState.java:34
 msgid "Failed update"
-msgstr ""
+msgstr "Оновлення не вдалося"
 
 #: libreplan-business/src/main/java/org/libreplan/business/planner/entities/SubcontractState.java:35
 msgid "Success sent"
-msgstr ""
+msgstr "Надіслано успішно"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:32
+msgid "as soon as possible"
+msgstr "якомога раніше"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:39
+msgid "start not earlier than"
+msgstr "початок не раніше ніж"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:46
+msgid "start in fixed date"
+msgstr "початок у фіксовану дату"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:58
+msgid "as late as possible"
+msgstr "якомога пізніше"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/PositionConstraintType.java:65
+msgid "finish not later than"
+msgstr "завершення не пізніше ніж"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:29
+msgid "In progress"
+msgstr "В процесі"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:30
+msgid "Pending"
+msgstr "Очікується"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:31
+msgid "Blocked"
+msgstr "Заблоковано"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskStatusEnum.java:32
+msgid "Ready to start"
+msgstr "Готово до початку"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:95
+msgid "There are no days available due to not satisfying the criteria."
+msgstr "Немає доступних днів через невиконання критеріїв."
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:103
+msgid "Maybe the criteria are not satisfied in those days."
+msgstr "Можливо, критерії не задовольняються у ці дні."
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:175
+msgid "Resource is not available from task's start"
+msgstr "Ресурс недоступний від дати початку завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/allocationalgorithms/ResourcesPerDayModification.java:180
+msgid "Resource is not available according to task's calendar"
+msgstr "Ресурс недоступний згідно з календарем завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/StretchesFunction.java:426
+msgid "Stretches must sum 100%"
+msgstr "Розтягнення мають складати 100%"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskDeadlineViolationStatusEnum.java:35
+msgid "Deadline violated"
+msgstr "Кінцевий термін порушено"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:73
+msgid "Flat"
+msgstr "Рівномірний"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:75
+msgid "Stretches"
+msgstr "Розтягнення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:76
+msgid "Interpolation"
+msgstr "Інтерполяція"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/entities/AssignmentFunction.java:77
+msgid "Sigmoid"
+msgstr "Сигмоїда"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/limiting/entities/LimitingResourceQueueDependency.java:170
+msgid "A queue dependency has to have an origin different from destiny"
+msgstr "Залежність черги повинна мати джерело, відмінне від призначення"
+
+#: libreplan-business/src/main/java/org/libreplan/business/planner/limiting/entities/QueuePosition.java:53
+msgid "Hour should be between 0 and 23"
+msgstr "Година має бути від 0 до 23"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/IssueTypeEnum.java:13
+msgid "Problem or concern"
+msgstr "Проблема або занепокоєння"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/IssueTypeEnum.java:13
+msgid "Request for change"
+msgstr "Запит на зміну"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/IssueTypeEnum.java:13
+msgid "Off specification"
+msgstr "Відхилення від специфікації"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "0"
+msgstr "0"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "1"
+msgstr "1"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "2"
+msgstr "2"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "3"
+msgstr "3"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "4"
+msgstr "4"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "6"
+msgstr "6"
+
+#: libreplan-business/src/main/java/org/libreplan/business/logs/entities/RiskScoreStatesEnum.java:11
+msgid "9"
+msgstr "9"
+
+#: libreplan-business/src/main/java/org/libreplan/business/templates/entities/OrderLineTemplate.java:166
+msgid "Line"
+msgstr "Рядок"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/Criterion.java:202
+msgid "[generic all machines]"
+msgstr "[загальні всі машини]"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceEnum.java:30
+msgid "WORKER"
+msgstr "ПРАЦІВНИК"
+
+#: libreplan-business/src/main/java/org/libreplan/business/resources/entities/ResourceEnum.java:31
+msgid "MACHINE"
+msgstr "МАШИНА"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormType.java:30
+msgid "by percentage"
+msgstr "за відсотком"
+
+#: libreplan-business/src/main/java/org/libreplan/business/qualityforms/entities/QualityFormType.java:30
+msgid "by items"
+msgstr "за елементами"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:31
+msgid "Number of assigned hours"
+msgstr "Кількість призначених годин"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:32
+msgid "Number of hours calculated by clock"
+msgstr "Кількість годин, обчислених за годинником"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/HoursManagementEnum.java:33
+msgid "Number of assigned hours and time"
+msgstr "Кількість призначених годин і час"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/PositionInWorkReportEnum.java:34
+msgid "heading"
+msgstr "заголовок"
+
+#: libreplan-business/src/main/java/org/libreplan/business/workreports/entities/PositionInWorkReportEnum.java:34
+msgid "line"
+msgstr "рядок"
 
 #: libreplan-business/src/main/java/org/libreplan/business/settings/entities/Language.java:36
 msgid "Use browser language configuration"
-msgstr ""
+msgstr "Використовувати мовні налаштування браузера"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:34
 msgid "Task assigned to resource"
-msgstr ""
+msgstr "Завдання призначено ресурсу"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:35
 msgid "Resource removed from task"
-msgstr ""
+msgstr "Ресурс видалено із завдання"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:36
 msgid "Milestone reached"
-msgstr ""
+msgstr "Віху досягнуто"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:37
 msgid "Task should start"
-msgstr ""
+msgstr "Завдання має розпочатися"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:38
 msgid "Task should finish"
-msgstr ""
+msgstr "Завдання має завершитися"
 
 #: libreplan-business/src/main/java/org/libreplan/business/email/entities/EmailTemplateEnum.java:39
 msgid "Enter data in timesheet"
-msgstr ""
+msgstr "Ввести дані в табель"
 
-#: libreplan-webapp/src/main/webapp/dashboard/_dashboardforglobal.zul:32
-msgid "Pipeline"
-msgstr ""
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorizationType.java:33
+msgid "Read authorization"
+msgstr "Дозвіл на читання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/OrderAuthorizationType.java:34
+msgid "Write authorization"
+msgstr "Дозвіл на запис"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:373
+msgid "Database"
+msgstr "База даних"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java:374
+msgid "LDAP"
+msgstr "LDAP"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:39
+msgid "Web service reader"
+msgstr "Читач веб-сервісу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:40
+msgid "Web service writer"
+msgstr "Запис веб-сервісу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:41
+msgid "Web service subcontractor operations"
+msgstr "Операції субпідрядника веб-сервісу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:44
+msgid "Read all projects"
+msgstr "Читати всі проєкти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:45
+msgid "Edit all projects"
+msgstr "Редагувати всі проєкти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:46
+msgid "Create projects"
+msgstr "Створювати проєкти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:54
+msgid "Import projects"
+msgstr "Імпортувати проєкти"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:81
+msgid "Hours Worked Per Resource Report"
+msgstr "Звіт про відпрацьовані години за ресурсом"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:82
+msgid "Total Worked Hours By Resource In A Month Report"
+msgstr "Звіт про загальні відпрацьовані години за ресурсом за місяць"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:83
+msgid "Work And Progress Per Project Report"
+msgstr "Звіт про роботу та прогрес за проєктом"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:84
+msgid "Work And Progress Per Task Report"
+msgstr "Звіт про роботу та прогрес за завданням"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:85
+msgid "Estimated/Planned Hours Per Task Report"
+msgstr "Звіт про розрахункові/заплановані години за завданням"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:86
+msgid "Project Costs Report"
+msgstr "Звіт про витрати проєкту"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:87
+msgid "Task Scheduling Status In Project Report"
+msgstr "Звіт про стан планування завдань у проєкті"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:88
+msgid "Materials Needed At Date Report"
+msgstr "Звіт про матеріали, необхідні на дату"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:92
+msgid "Use files for order"
+msgstr "Використовувати файли для проєкту"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:94
+msgid "Email: task assigned to resource"
+msgstr "Email: завдання призначено ресурсу"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:95
+msgid "Email: resource removed from task"
+msgstr "Email: ресурс видалено із завдання"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:96
+msgid "Email: milestone reached"
+msgstr "Email: віху досягнуто"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:97
+msgid "Email: task should finish"
+msgstr "Email: завдання має завершитися"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:98
+msgid "Email: task should start"
+msgstr "Email: завдання має розпочатися"
+
+#: libreplan-business/src/main/java/org/libreplan/business/users/entities/UserRole.java:99
+msgid "Email: timesheet data missing"
+msgstr "Email: відсутні дані табелю"

--- a/libreplan-webapp/src/main/resources/i18n/uk.po
+++ b/libreplan-webapp/src/main/resources/i18n/uk.po
@@ -1,8 +1,8 @@
-# SOME DESCRIPTIVE TITLE.
+# Ukrainian translation for LibrePlan.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+# Translators:
 msgid ""
 msgstr ""
 "Project-Id-Version: LibrePlan\n"


### PR DESCRIPTION
Translate all UI strings for both the webapp (2,019 entries) and ganttzk (60 entries) components into Ukrainian, covering the full set of messages from keys.pot templates.