### PR TITLE
Fix $.browser incompatibility between jQuery 4.0 and jqplot 1.0.4.

### DIFF
--- a/libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul
+++ b/libreplan-webapp/src/main/webapp/dashboard/_dashboardfororder.zul
@@ -168,6 +168,15 @@
         ]]>
     </n:script>
 
+    <!-- $.browser was removed in jQuery 1.9; jqplot 1.0.4 still references it -->
+    <n:script type="text/javascript">
+        <![CDATA[
+            if (!jQuery.browser) {
+                jQuery.browser = { msie: false, version: 0 };
+            }
+        ]]>
+    </n:script>
+
     <n:script type="text/javascript">
         <![CDATA[
             ${jquery_jqplot_min_js}


### PR DESCRIPTION
Add a $.browser shim before jqplot loads to prevent "can't access property 'msie', $.browser is undefined" error on the project dashboard page. Fixes #2040.