### PR TITLE
Some small fixes in the Personal timesheet search dialog

### DIFF
--- a/libreplan-webapp/src/main/java/org/libreplan/web/workreports/WorkReportCRUDController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/workreports/WorkReportCRUDController.java
@@ -675,6 +675,7 @@ public class WorkReportCRUDController
     @Override
     public void goToCreateForm(WorkReportType workReportType) {
         if ( workReportType.isPersonalTimesheetsType() ) {
+            personalTimesheetsBandboxSearch.setModel(workReportModel.getBoundWorkers());
             personalTimesheetsPopup.open(listTypeToAssign);
         } else {
             cameBackList = false;

--- a/libreplan-webapp/src/main/webapp/common/components/bandboxSearch.zul
+++ b/libreplan-webapp/src/main/webapp/common/components/bandboxSearch.zul
@@ -37,10 +37,10 @@
 
     <bandbox id="bandbox" autodrop="true">
         <bandpopup>
-            <vbox height="50px">
+            <vbox height="170px">
                 <listbox id="listbox" width="200px" sclass="bandbox-search" height="150px"
                          model="${arg.model}"
-                         c:onClick="closeBandbox(this.$f().bandbox.parent);">
+                         c:onClick="closeBandbox(this.$f('bandbox').parent);">
                     <listhead id="listhead" />
                 </listbox>
             </vbox>


### PR DESCRIPTION
While researching something that was basically a PEBKAC some improvements were made.

What was fixed:

- Bug fix 1 (WorkReportCRUDController.java): Explicitly refresh the bandbox model with getBoundWorkers() when opening the popup, instead of relying on the deprecated AnnotateDataBinder which was silently failing in ZK 8.
- Bug fix 2 (bandboxSearch.zul): Increased vbox height from 50px to 170px so the list isn't clipped.
- Bug fix 3 (bandboxSearch.zul): Fixed this.$f() → this.$f('bandbox') for correct ZK 8 component lookup on click.

The data requirement (workers must be linked to a user account to appear in the personal timesheet popup) is by design — personal timesheets are only meaningful for workers who can log in and access them.
