### PR TITLE
Report screens had for some reason a thicker border than usual.

### DIFF
--- a/libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul
+++ b/libreplan-webapp/src/main/webapp/reports/completedEstimatedHoursPerTask.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.CompletedEstimatedHoursPerTaskController"
-            title="${i18n:_t('Estimated/Planned Hours Per Task')}"
-            border="normal" >
+            title="${i18n:_t('Estimated/Planned Hours Per Task')}">
 
         <!-- Select deadline date -->
         <panel title="${i18n:_t('Date')}" border="normal" style="overflow:auto" sclass="report-margin">

--- a/libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerInAMonthReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.HoursWorkedPerWorkerInAMonthController"
-            title="${i18n:_t('Total Worked Hours By Resource In A Month')}"
-            border="normal" >
+            title="${i18n:_t('Total Worked Hours By Resource In A Month')}">
 
         <!-- Select workers -->
         <panel title="${i18n:_t('Filter by month')}" border="normal" style="overflow:auto" sclass="report-margin">

--- a/libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/hoursWorkedPerWorkerReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.HoursWorkedPerWorkerController"
-            title="${i18n:_t('Hours Worked Per Resource')}"
-            border="normal" >
+            title="${i18n:_t('Hours Worked Per Resource')}">
 
         <!-- Select dates -->
 

--- a/libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/projectStatusReport.zul
@@ -33,8 +33,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.ProjectStatusReportController"
-            title="${i18n:_t('Project Status Report')}"
-            border="normal" >
+            title="${i18n:_t('Project Status Report')}">
 
         <vbox id="messagesContainer" />
 

--- a/libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/schedulingProgressPerOrderReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.SchedulingProgressPerOrderController"
-            title="${i18n:_t('Work And Progress Per Project')}"
-            border="normal" >
+            title="${i18n:_t('Work And Progress Per Project')}">
 
         <!-- Select dates -->
         <panel title="${i18n:_t('Date')}" border="normal" style="overflow:auto" sclass="report-margin">

--- a/libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/timeLineMaterialReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.TimeLineRequiredMaterialController"
-            title="${i18n:_t('Materials Needed At Date')}"
-            border="normal">
+            title="${i18n:_t('Materials Needed At Date')}">
         <hbox>
             <div>
                 <!-- Select dates -->

--- a/libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/workingArrangementsPerOrderReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.WorkingArrangementsPerOrderController"
-            title="${i18n:_t('Task Scheduling Status In Project')}"
-            border="normal" >
+            title="${i18n:_t('Task Scheduling Status In Project')}">
 
         <!-- Select orders -->
         <panel title="${i18n:_t('Filter by projects')}"

--- a/libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul
+++ b/libreplan-webapp/src/main/webapp/reports/workingProgressPerTaskReport.zul
@@ -36,8 +36,7 @@
 
     <window self="@{define(content)}"
             apply="org.libreplan.web.reports.WorkingProgressPerTaskController"
-            title="${i18n:_t('Work And Progress Per Task')}"
-            border="normal" >
+            title="${i18n:_t('Work And Progress Per Task')}">
 
         <!-- Select deadline date -->
         <panel title="${i18n:_t('Date')}" border="normal" style="overflow:auto" sclass="report-margin">


### PR DESCRIPTION

All other Libreplan screens have <window self="@{define(content)}"> without a border attribute,
but all report ZUL files had border="normal" on their window. 
That's what was causing a thicker border. Fixed and tested.