### PR TITLE
Fixing inability to upload files.

### DIFF
--- a/libreplan-webapp/src/main/java/org/libreplan/web/orders/files/OrderFilesController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/orders/files/OrderFilesController.java
@@ -223,39 +223,39 @@ public class OrderFilesController extends GenericForwardComposer {
         if ( isRepositoryExists() ) {
 
             String projectCode = orderElementModel.getOrderElement().getCode();
-            directory = configurationModel.getRepositoryLocation() + "orders" + "/" + projectCode;
 
             try {
-                // Location of file: libreplan-webapp/src/main/webapp/planner/fileupload.zul
-                Fileupload.setTemplate("fileupload.zul");
+                Fileupload.setTemplate("/planner/fileupload.zul");
 
                 Media media = Fileupload.get();
+
+                if ( media == null ) {
+                    return;
+                }
+
+                String repoLocation = configurationModel.getRepositoryLocation();
+                if ( !repoLocation.endsWith("/") ) {
+                    repoLocation += "/";
+                }
+                directory = repoLocation + "orders/" + projectCode;
 
                 File dir = new File(directory);
                 String filename = media.getName();
                 File file = new File(dir, filename);
 
-                // By default Java do not create directories itself
                 file.getParentFile().mkdirs();
 
-                OutputStream outputStream = new FileOutputStream(file);
+                try ( OutputStream outputStream = new FileOutputStream(file);
+                      InputStream inputStream = media.isBinary()
+                              ? media.getStreamData()
+                              : new ReaderInputStream(media.getReaderData()) ) {
 
-                InputStream inputStream = media.isBinary()
-                        ? media.getStreamData()
-                        : new ReaderInputStream(media.getReaderData());
-
-                if ( inputStream != null ) {
-                    byte[] buffer = new byte[1024];
-                    for ( int count; (count = inputStream.read(buffer)) != -1; ) {
-                        outputStream.write(buffer, 0, count);
+                    if ( inputStream != null ) {
+                        byte[] buffer = new byte[1024];
+                        for ( int count; (count = inputStream.read(buffer)) != -1; ) {
+                            outputStream.write(buffer, 0, count);
+                        }
                     }
-                }
-
-                outputStream.flush();
-                outputStream.close();
-
-                if (inputStream != null) {
-                    inputStream.close();
                 }
 
                 orderFileModel.createNewFileObject();
@@ -271,9 +271,11 @@ public class OrderFilesController extends GenericForwardComposer {
 
                 orderFileModel.confirmSave();
 
+                messages.showMessage(Level.INFO, _t("File uploaded successfully"));
 
             } catch (Exception e){
                 e.printStackTrace();
+                messages.showMessage(Level.ERROR, _t("Error uploading file: ") + e.getMessage());
             }
 
             finally {

--- a/libreplan-webapp/src/main/webapp/planner/fileupload.zul
+++ b/libreplan-webapp/src/main/webapp/planner/fileupload.zul
@@ -44,17 +44,17 @@ Copyright (C) 2005 Potix Corporation. All Rights Reserved.
 <?component name="submit" extends="button" widgetClass="zul.fud.Submit"?>
 <?taglib uri="/WEB-INF/tld/i18n.tld" prefix="i18n"?>
 
-<uploaddlg title="${arg.title}" shadow="false" border="normal" width="360px" closable="true"
+<uploaddlg title="${arg.title}" uploadListener="${arg.listener}" shadow="false" border="normal" width="360px" closable="true"
            xmlns:w="http://www.zkoss.org/2005/zk/client"
            w:onClose="this.cancel()" w:max="${arg.max}">
 
     <label value="${i18n:_t('Please select a file on your system')}"/>
 
     <fileupload id="fileupload" forward="onUpload=" label="${c:l('mesg:org.zkoss.zul.mesg.MZul:UPLOAD_BROWSE')}"
-                upload="zul.fud.ModalFileViewer,maxsize=${arg.maxsize}${arg.native ? ',native':''}"/>
+                upload="zul.fud.ModalFileViewer,maxsize=${arg.maxsize}${arg['accept'] != null ? c:cat(',accept=', arg['accept']) : ''}${arg['native'] ? ',native':''}"/>
 
     <separator bar="true"/>
-    <div id="uploaded" visible="false"/>
+    <div id="uploaded" visible="false"></div>
     <div id="btns">
 
         <submit id="submit" label="${c:l('mesg:org.zkoss.zul.mesg.MZul:UPLOAD_SUBMIT')}" w:onClick="this.submit()"/>

--- a/pom.xml
+++ b/pom.xml
@@ -694,7 +694,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.11.0</version>
+                <version>2.19.0</version>
             </dependency>
 
             <!-- Quartz framework -->


### PR DESCRIPTION
1. NPE on cancel — null guard added when user cancels the upload dialog
2. Broken fileupload.zul template — three divergences from the ZK 8.6 built-in fixed (missing uploadListener, bracket notation for native, explicit closing tag for uploaded div)
3. commons-io version mismatch — bumped from 2.11.0 → 2.19.0 to match what commons-fileupload 1.6.0 requires