### PR TITLE
Fix duplicate Woodstox / Stax2 JARs in WAR (fixes #2067)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,16 @@
                 <version>2.0.1</version>
             </dependency>
 
-            <!-- CXF -->
+            <!--
+                CXF.
+                cxf-core:3.1.7 (transitive) declares the obsolete
+                org.codehaus.woodstox:woodstox-core-asl:4.4.1 as a direct dependency.
+                That jar ships its own copy of org.codehaus.stax2.* classes and
+                collides with the modern com.fasterxml.woodstox:woodstox-core,
+                causing a NoSuchMethodError at Spring/Hibernate bootstrap
+                (LibrePlan issue #2067). Exclude it from every CXF entry that
+                pulls cxf-core.
+            -->
             <dependency>
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
@@ -599,6 +608,10 @@
                         <groupId>org.springframework</groupId>
                         <artifactId>spring-web</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -619,6 +632,10 @@
                         <groupId>org.springframework</groupId>
                         <artifactId>spring-context</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -626,6 +643,12 @@
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-rs-client</artifactId>
                 <version>3.1.7</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.codehaus.woodstox</groupId>
+                        <artifactId>woodstox-core-asl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Jackson provider -->
@@ -854,6 +877,12 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.6</version>
                 <configuration>
+                    <!--
+                        Safety net for LibrePlan #2067: keep the obsolete
+                        woodstox-core-asl jar out of WEB-INF/lib even if some
+                        future transitive dependency re-introduces it.
+                    -->
+                    <packagingExcludes>WEB-INF/lib/woodstox-core-asl-*.jar</packagingExcludes>
                     <webResources>
                         <resource>
                             <directory>src/main/webapp/META-INF</directory>


### PR DESCRIPTION
## Summary

- Excludes the obsolete `org.codehaus.woodstox:woodstox-core-asl:4.4.1` from the three CXF dependencies in `dependencyManagement`. This jar is pulled in transitively by `cxf-core:3.1.7` and ships its own incompatible copy of `org.codehaus.stax2.*` classes, colliding with the modern `com.fasterxml.woodstox:woodstox-core:6.2.7` already on the classpath via `saaj-impl:1.5.1`.
- Adds a `<packagingExcludes>WEB-INF/lib/woodstox-core-asl-*.jar</packagingExcludes>` safety net to `maven-war-plugin` in case a future transitive dependency re-introduces the obsolete jar.

Fixes the `NoSuchMethodError` on `org.codehaus.stax2.ri.EmptyIterator.getInstance()` thrown during Spring/Hibernate `sessionFactory` initialization that prevents the 1.6.0 Docker image from starting on Tomcat 9 / JDK 21.

Fixes #2067. Diagnosis credit to @Interfud.

A follow-up PR will add a `maven-enforcer-plugin` `banDuplicateClasses` rule to catch this category of issue at build time.

## Verification

`mvn -pl libreplan-webapp -am dependency:tree | grep -iE 'woodstox|stax'` now reports only:

```
|     +- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
|     \- com.fasterxml.woodstox:woodstox-core:jar:6.2.7:compile
|  \- org.jvnet.staxex:stax-ex:jar:1.8.1:compile
```

No more `woodstox-core-asl:4.4.1` anywhere in the resolved tree.

## Test plan

- [x] `mvn clean package -P postgresql,dev,i18n,reports -DskipTests -Dliquibase.skip=true` produces a WAR
- [x] `unzip -l libreplan-webapp/target/libreplan-webapp.war | grep -E 'woodstox|stax2'` shows only the modern `woodstox-core-*.jar` and `stax2-api-*.jar` — no `woodstox-core-asl-*.jar`
- [x] Rebuild the `libreplan/libreplan:1.6.0` Docker image, run with the docker-compose stack from issue #2067, and confirm the Spring context starts cleanly and the app responds at `localhost:8080`
- [x] Existing CXF JAX-RS endpoints still function (smoke-test web service entry points)