### PR TITLE
Fix NonUniqueObjectException on first Save of a project

### DIFF
--- a/libreplan-business/src/test/java/org/libreplan/business/test/orders/daos/OrderDAOTest.java
+++ b/libreplan-business/src/test/java/org/libreplan/business/test/orders/daos/OrderDAOTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.libreplan.business.BusinessGlobalNames.BUSINESS_SPRING_CONFIG_FILE;
 import static org.libreplan.business.test.BusinessGlobalNames.BUSINESS_SPRING_CONFIG_TEST_FILE;
 
@@ -38,6 +39,7 @@ import org.libreplan.business.calendars.daos.IBaseCalendarDAO;
 import org.libreplan.business.calendars.entities.BaseCalendar;
 import org.libreplan.business.common.IAdHocTransactionService;
 import org.libreplan.business.common.IOnTransaction;
+import org.libreplan.business.common.exceptions.InstanceNotFoundException;
 import org.libreplan.business.common.exceptions.ValidationException;
 import org.libreplan.business.externalcompanies.entities.DeadlineCommunication;
 import org.libreplan.business.orders.daos.IOrderDAO;
@@ -203,6 +205,113 @@ public class OrderDAOTest {
                 return null;
             }
         });
+    }
+
+    /**
+     * Regression test for a production bug where saving a project ("Test1") failed on the very
+     * first Save click, with no user edits, throwing:
+     * <pre>
+     * org.hibernate.NonUniqueObjectException: A different object with the same identifier value
+     * was already associated with the session : [org.libreplan.business.orders.entities.Order#...]
+     * </pre>
+     *
+     * Root cause: {@code SaveCommandBuilder.doTheSaving()} (libreplan-webapp) receives a detached
+     * {@code Order} (carried over from an earlier, already-closed request/session - the normal way
+     * ZK's long-lived planning conversation works) and calls {@code state.synchronizeTrees()} before
+     * ever reattaching it. That triggers a lazy/eager load (via
+     * {@code SchedulingDataForVersion.orderElement}, mapped {@code fetch="join"}) that resolves to a
+     * FRESH, separate {@code Order} instance for the same id, since the original detached instance
+     * was never registered in the new transaction's session. The later
+     * {@code orderDAO.save(order)} call then fails, because Hibernate finds two different Java
+     * objects claiming the same identity in one session.
+     *
+     * The fix ({@code orderDAO.reattach(order)} at the very start of {@code doTheSaving()}) makes
+     * the detached instance the session's canonical managed object first, so any later load of the
+     * same id resolves to it instead of creating a conflicting duplicate.
+     *
+     * This test reproduces the exact Hibernate mechanism directly at the DAO layer - deterministic
+     * and independent of the specific scheduling-tree shape that triggered it in production - and
+     * was verified against the real regression (v1.6.1, live "Test1" data restored from production)
+     * before being reduced to this minimal form. See project memory for the full incident writeup.
+     */
+    @Test
+    @Transactional
+    public void savingADetachedOrderAfterAnotherInstanceIsAlreadyInTheSessionThrowsNonUniqueObjectException() {
+        final Long orderId = transactionService.runOnAnotherTransaction(new IOnTransaction<Long>() {
+            @Override
+            public Long execute() {
+                Order order = createValidOrder("reattach-regression-" + UUID.randomUUID());
+                orderDAO.save(order);
+                orderDAO.flush();
+                return order.getId();
+            }
+        });
+
+        // A genuinely detached Java object: loaded in its own transaction, whose session has since
+        // closed - exactly like `state.getOrder()` in SaveCommandBuilder, carried over from an
+        // earlier ZK request.
+        final Order detachedOrder = transactionService.runOnAnotherTransaction(new IOnTransaction<Order>() {
+            @Override
+            public Order execute() {
+                try {
+                    return orderDAO.find(orderId);
+                } catch (InstanceNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        // Without reattaching first: once something else has loaded a DIFFERENT instance for the
+        // same id into the session, saving the original detached reference must fail - this is the
+        // original bug, reproduced directly.
+        try {
+            transactionService.runOnAnotherTransaction(new IOnTransaction<Void>() {
+                @Override
+                public Void execute() {
+                    try {
+                        orderDAO.find(orderId); // loads a fresh, different Order instance
+                    } catch (InstanceNotFoundException e) {
+                        throw new RuntimeException(e);
+                    }
+                    orderDAO.save(detachedOrder); // same id, different instance -> must fail
+                    return null;
+                }
+            });
+            fail("Expected saving a stale detached Order after a different instance for the same id "
+                    + "was already loaded in the session to throw a NonUniqueObjectException, "
+                    + "reproducing the original 'Test1' project production bug.");
+        } catch (RuntimeException expected) {
+            assertNonUniqueObjectExceptionSomewhereInCauseChain(expected);
+        }
+
+        // The fix: reattaching first makes the detached instance the session's managed instance, so
+        // a later load of the same id resolves to it instead of conflicting.
+        transactionService.runOnAnotherTransaction(new IOnTransaction<Void>() {
+            @Override
+            public Void execute() {
+                orderDAO.reattach(detachedOrder);
+                try {
+                    orderDAO.find(orderId);
+                } catch (InstanceNotFoundException e) {
+                    throw new RuntimeException(e);
+                }
+                orderDAO.save(detachedOrder);
+                orderDAO.flush();
+                return null;
+            }
+        });
+    }
+
+    private static void assertNonUniqueObjectExceptionSomewhereInCauseChain(Throwable t) {
+        Throwable current = t;
+        while (current != null) {
+            if (current instanceof org.hibernate.NonUniqueObjectException) {
+                return;
+            }
+            current = current.getCause();
+        }
+        throw new AssertionError(
+                "Expected a NonUniqueObjectException somewhere in the cause chain of: " + t, t);
     }
 
 }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/planner/order/SaveCommandBuilder.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/planner/order/SaveCommandBuilder.java
@@ -360,6 +360,19 @@ public class SaveCommandBuilder {
 
         private void doTheSaving() {
             Order order = state.getOrder();
+
+            // `order` can be a detached instance carried over from an earlier, already-closed
+            // request (ZK's planning conversation spans many requests). Reattach it to this
+            // transaction's session before anything else touches the scheduling tree: otherwise
+            // state.synchronizeTrees() (via calculateSynchronizationsNeeded(), walking
+            // TaskSource -> SchedulingDataForVersion -> OrderElement, mapped fetch="join") can load
+            // a second, independent Order instance for the same id, and the later orderDAO.save(order)
+            // below then fails with NonUniqueObjectException - this was a real production bug (first
+            // Save on a project always failed, even with no edits). Reattaching first makes `order`
+            // the session's canonical managed instance, so any later load of the same id resolves to
+            // it instead of conflicting. See OrderDAOTest for a regression test of this mechanism.
+            orderDAO.reattach(order);
+
             generateOrderElementCodes(order);
             createAdvancePercentagesIfRequired(order);
             order.calculateAndSetTotalHours();


### PR DESCRIPTION
Order (a detached instance carried over from an earlier request) was never reattached to the session before state.synchronizeTrees() ran. That method eagerly loads OrderElement/Order data via TaskSource -> SchedulingDataForVersion (fetch="join"), producing a second, separate Order instance for the same id; the later orderDAO.save(order) then failed with NonUniqueObjectException, even with zero edits.

Reattach order at the top of doTheSaving(), before anything touches the tree, mirroring the existing taskElementDAO.reattach(rootTask) a few lines below for the same class of bug.

Verified against the real "Test1" production data (restored from the demo server) that originally triggered this, plus concurrent-editors, concurrent-different-projects, and repeated-save load tests. Added a regression test (OrderDAOTest) that reproduces the exact Hibernate session-identity mechanism directly.